### PR TITLE
Improvement/ingress

### DIFF
--- a/.github/workflows/codeCov.yml
+++ b/.github/workflows/codeCov.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches:    
+    branches:
         - master         # Push events on master branch
 
 name: CodeCoverage
@@ -27,4 +27,4 @@ jobs:
       - name: Test Code Coverage
         uses: actions-rs/tarpaulin@v0.1
         with:
-          args: '-- -test-threads 1'
+          args: '--ignore-tests -- -test-threads 1'

--- a/atat/Cargo.toml
+++ b/atat/Cargo.toml
@@ -41,8 +41,6 @@ stm32l4xx-hal = { git = "https://github.com/stm32-rs/stm32l4xx-hal", features = 
 embedded-hal-mock = "0.7.1"
 
 [features]
-default = ["derive", "error-message"]
+default = ["derive"]
 
-logging = []
-error-message = ["atat_derive/error-message"]
 derive = ["atat_derive"]

--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -688,15 +688,8 @@ mod test {
 
         assert_eq!(client.state, ClientState::Idle);
 
-        #[cfg(feature = "error-message")]
-        let expectation = nb::Error::Other(Error::InvalidResponseWithMessage(String::from(
-            "+CUN: 22,16,22",
-        )));
-        #[cfg(not(feature = "error-message"))]
-        let expectation = nb::Error::Other(Error::InvalidResponse);
-
         match client.send(&cmd) {
-            Err(error) => assert_eq!(error, expectation),
+            Err(error) => assert_eq!(error, nb::Error::Other(Error::InvalidResponse)),
             _ => panic!("Panic send error in test"),
         }
         assert_eq!(client.state, ClientState::Idle);

--- a/atat/src/error.rs
+++ b/atat/src/error.rs
@@ -13,9 +13,6 @@ pub enum Error {
     /// Invalid response from module
     InvalidResponse,
 
-    #[cfg(feature = "error-message")]
-    InvalidResponseWithMessage(heapless::String<heapless::consts::U256>),
-
     ResponseError,
 
     Aborted,

--- a/atat/src/ingress_manager.rs
+++ b/atat/src/ingress_manager.rs
@@ -12,6 +12,33 @@ type ResProducer = Producer<'static, Result<String<consts::U256>>, consts::U5, u
 type UrcProducer = Producer<'static, String<consts::U64>, consts::U10, u8>;
 type ComConsumer = Consumer<'static, Command, consts::U3, u8>;
 
+fn get_line<L: ArrayLength<u8>, I: ArrayLength<u8>>(
+    buf: &mut String<I>,
+    s: &str,
+    line_term_char: u8,
+    format_char: u8,
+    trim_response: bool,
+) -> Option<String<L>> {
+    match buf.match_indices(s).next() {
+        Some((mut index, _)) => {
+            while match buf.get(index..=index) {
+                Some(c) => c.as_bytes()[0] == line_term_char || c.as_bytes()[0] == format_char,
+                _ => false,
+            } {
+                index += 1;
+            }
+
+            let return_string = {
+                let part = unsafe { buf.get_unchecked(0..index) };
+                String::from(if trim_response { part.trim() } else { part })
+            };
+            *buf = String::from(unsafe { buf.get_unchecked(index..buf.len()) });
+            Some(return_string)
+        }
+        None => None,
+    }
+}
+
 /// State of the IngressManager, used to destiguish URC's from solicited
 /// responses
 #[derive(Clone, PartialEq, Debug)]
@@ -27,9 +54,9 @@ pub struct IngressManager {
     com_c: ComConsumer,
     state: State,
     /// Command line termination character S3 (Default = '\r' [013])
-    line_term_char: char,
+    line_term_char: u8,
     /// Response formatting character S4 (Default = '\n' [010])
-    format_char: char,
+    format_char: u8,
     echo_enabled: bool,
 }
 
@@ -62,19 +89,6 @@ impl IngressManager {
                 Err(_) => self.notify_response(Err(Error::Overflow)),
             }
         }
-    }
-
-    fn take_trim_substring<L: ArrayLength<u8>>(&mut self, index: usize) -> String<L> {
-        let mut result = String::new();
-        let mut return_string: String<L> = String::new();
-        return_string
-            .push_str(unsafe { self.buf.get_unchecked(0..index).trim() })
-            .ok();
-        result
-            .push_str(unsafe { self.buf.get_unchecked(index..self.buf.len()) })
-            .ok();
-        self.buf = result;
-        return_string
     }
 
     fn notify_response(&mut self, resp: Result<String<consts::U256>>) {
@@ -116,66 +130,76 @@ impl IngressManager {
 
     pub fn parse_at(&mut self) {
         self.handle_com();
-        log::info!("{:?} - [{:?}]\r", self.state, self.buf);
+        if self.buf.starts_with(self.line_term_char as char)
+            || self.buf.starts_with(self.format_char as char)
+        {
+            // TODO: Custom trim_start, that trims based on line_term_char and format_char
+            self.buf = String::from(self.buf.trim_start());
+        }
+        if self.buf.len() > 0 {
+            log::trace!("{:?} - [{:?}]\r", self.state, self.buf);
+        }
         match self.state {
             State::Idle => {
                 if self.echo_enabled && self.buf.starts_with("AT") {
-                    if let Some((mut index, _)) = self.buf.match_indices(self.line_term_char).next()
-                    {
+                    if let Some(_) = get_line::<consts::U64, _>(
+                        &mut self.buf,
+                        // FIXME: Use `self.line_term_char` here
+                        "\r",
+                        self.line_term_char,
+                        self.format_char,
+                        false,
+                    ) {
                         self.state = State::ReceivingResponse;
-                        let mut tmp = [0; 1];
-                        while match self.buf.get(index..=index) {
-                            Some(c) => {
-                                c == self.line_term_char.encode_utf8(&mut tmp)
-                                    || c == self.format_char.encode_utf8(&mut tmp)
-                            }
-                            _ => false,
-                        } {
-                            index += 1;
-                        }
-                        self.take_trim_substring::<consts::U64>(index);
                     }
                 } else if !self.echo_enabled {
                     unimplemented!("Disabling AT echo is currently unsupported");
                 } else if self.buf.starts_with('+') {
-                    // Handle multiple urcs in same run!
-                    let resp = self.take_trim_substring(self.buf.len());
-                    self.notify_urc(resp);
-                    self.buf.clear();
+                    if let Some(line) = get_line(
+                        &mut self.buf,
+                        // FIXME: Use `self.line_term_char` here
+                        "\r",
+                        self.line_term_char,
+                        self.format_char,
+                        false,
+                    ) {
+                        self.notify_urc(line);
+                    }
                 } else {
                     self.buf.clear();
                 }
             }
             State::ReceivingResponse => {
-                if self.buf.starts_with(self.line_term_char)
-                    || self.buf.starts_with(self.format_char)
+                let resp = if let Some(mut line) = get_line::<consts::U64, _>(
+                    &mut self.buf,
+                    // FIXME: Use `self.format_char` and `self.line_term_char` here
+                    "OK\r\n",
+                    self.line_term_char,
+                    self.format_char,
+                    false,
+                ) {
+                    Ok(
+                        // FIXME: Use `self.line_term_char` here
+                        get_line(&mut line, "\r", self.line_term_char, self.format_char, true)
+                            .unwrap_or_else(|| String::new()),
+                    )
+                } else if get_line::<consts::U64, _>(
+                    &mut self.buf,
+                    // FIXME: Use `self.format_char` and `self.line_term_char` here
+                    "ERROR\r\n",
+                    self.line_term_char,
+                    self.format_char,
+                    false,
+                )
+                .is_some()
                 {
-                    // TODO: Custom trim_start, that trims based on line_term_char and format_char
-                    self.buf = String::from(self.buf.trim_start());
-                }
-
-                // TODO: Use `self.format_char` and `self.line_term_char` in these rmatches
-                let (index, err) = if let Some(index) = self.buf.rmatch_indices("OK\r\n").next() {
-                    (index.0, None)
-                } else if let Some(index) = self.buf.rmatch_indices("ERROR\r\n").next() {
-                    #[cfg(not(feature = "error-message"))]
-                    let err = Error::InvalidResponse;
-                    #[cfg(feature = "error-message")]
-                    let err = Error::InvalidResponseWithMessage(self.buf.clone());
-
-                    (index.0, Some(err))
+                    Err(Error::InvalidResponse)
                 } else {
                     return;
                 };
 
-                let resp = self.take_trim_substring(index);
-                self.notify_response(match err {
-                    None => Ok(resp),
-                    Some(e) => Err(e),
-                });
-
+                self.notify_response(resp);
                 self.state = State::Idle;
-                self.buf.clear();
             }
         }
     }
@@ -185,12 +209,11 @@ impl IngressManager {
 #[cfg_attr(tarpaulin, skip)]
 mod test {
     // extern crate test;
+    // use test::Bencher;
 
     use super::*;
     use crate as atat;
-    // use test::Bencher;
     use atat::Mode;
-    use embedded_hal::serial::{self, Read};
     use heapless::{consts, spsc::Queue, String};
 
     #[test]
@@ -377,16 +400,9 @@ mod test {
         assert_eq!(at_pars.buf, String::<consts::U256>::from(""));
         assert_eq!(at_pars.state, State::Idle);
 
-        #[cfg(feature = "error-message")]
-        let expectation = Error::InvalidResponseWithMessage(String::from(
-            "+USORD: 3,16,\"16 bytes of data\"\r\nERROR\r\n",
-        ));
-        #[cfg(not(feature = "error-message"))]
-        let expectation = Error::InvalidResponse;
-
         if let Some(result) = c.dequeue() {
             match result {
-                Err(e) => assert_eq!(e, expectation),
+                Err(e) => assert_eq!(e, Error::InvalidResponse),
                 Ok(resp) => {
                     panic!("Dequeue Ok: {:?}", resp);
                 }

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -1,4 +1,4 @@
-// #![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(test), no_std)]
 // #![feature(test)]
 
 #[macro_use]

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), no_std)]
+// #![cfg_attr(not(test), no_std)]
 // #![feature(test)]
 
 #[macro_use]

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -41,16 +41,16 @@ pub enum Mode {
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Command {
     ClearBuffer,
-    SetLineTerm(char),
-    SetFormat(char),
+    SetLineTerm(u8),
+    SetFormat(u8),
     SetEcho(bool),
 }
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Config {
     mode: Mode,
-    line_term_char: char,
-    format_char: char,
+    line_term_char: u8,
+    format_char: u8,
     at_echo_enabled: bool,
     cmd_cooldown: u32,
 }
@@ -59,8 +59,8 @@ impl Default for Config {
     fn default() -> Config {
         Config {
             mode: Mode::Blocking,
-            line_term_char: '\r',
-            format_char: '\n',
+            line_term_char: '\r' as u8,
+            format_char: '\n' as u8,
             at_echo_enabled: true,
             cmd_cooldown: 20,
         }
@@ -75,12 +75,12 @@ impl Config {
         }
     }
 
-    pub fn with_line_term(mut self, c: char) -> Self {
+    pub fn with_line_term(mut self, c: u8) -> Self {
         self.line_term_char = c;
         self
     }
 
-    pub fn with_format_char(mut self, c: char) -> Self {
+    pub fn with_format_char(mut self, c: u8) -> Self {
         self.format_char = c;
         self
     }

--- a/atat_derive/Cargo.toml
+++ b/atat_derive/Cargo.toml
@@ -18,7 +18,3 @@ serde_at = { path = "../serde_at", version = "0.1.8-alpha.0" }
 
 [lib]
 proc-macro = true
-
-[features]
-default = ["error-message"]
-error-message = []

--- a/atat_derive/src/cmd.rs
+++ b/atat_derive/src/cmd.rs
@@ -111,11 +111,6 @@ fn generate_cmd_output(
 
     let value_sep = &attr.value_sep;
 
-    #[cfg(feature = "error-message")]
-    let invalid_resp_err = quote! { atat::Error::InvalidResponseWithMessage(String::from(resp)) };
-    #[cfg(not(feature = "error-message"))]
-    let invalid_resp_err = quote! { atat::Error::InvalidResponse };
-
     TokenStream::from(quote! {
         #[automatically_derived]
         impl #impl_generics atat::ATATCmd for #name #ty_generics #where_clause {
@@ -132,7 +127,7 @@ fn generate_cmd_output(
 
             fn parse(&self, resp: &str) -> core::result::Result<#response, atat::Error> {
                 serde_at::from_str::<#response>(resp).map_err(|e| {
-                    #invalid_resp_err
+                    atat::Error::InvalidResponse
                 })
             }
 


### PR DESCRIPTION
Correctly handle cases where `parse_at()` is fired in the middle of receiving, and cases where there is more than one response between calling `parse_at()`, thus receiving URC's and responses