### PR TITLE
Improved ingress logging

### DIFF
--- a/atat/src/ingress_manager.rs
+++ b/atat/src/ingress_manager.rs
@@ -99,7 +99,7 @@ impl IngressManager {
     /// be abstracted over the communication medium.
     pub fn write(&mut self, data: &[u8]) {
         #[cfg(feature = "logging")]
-        log::trace!("Ingress: Receiving {} bytes", data.len());
+        log::trace!("Receiving {} bytes", data.len());
         for byte in data {
             match self.buf.push(*byte as char) {
                 Ok(_) => {}
@@ -109,6 +109,8 @@ impl IngressManager {
     }
 
     fn notify_response(&mut self, resp: Result<String<consts::U256>, Error>) {
+        #[cfg(feature = "logging")]
+        log::debug!("Received response: {:?}", &resp);
         if self.res_p.ready() {
             self.res_p.enqueue(resp).ok();
         } else {
@@ -117,6 +119,8 @@ impl IngressManager {
     }
 
     fn notify_urc(&mut self, resp: String<consts::U64>) {
+        #[cfg(feature = "logging")]
+        log::debug!("Received URC: {:?}", &resp);
         if self.urc_p.ready() {
             self.urc_p.enqueue(resp).ok();
         } else {
@@ -154,7 +158,7 @@ impl IngressManager {
             self.buf = String::from(self.buf.trim_start());
         }
         #[cfg(feature = "logging")]
-        log::trace!("Ingress: Digest / {:?} / {:?}", self.state, self.buf);
+        log::trace!("Digest / {:?} / {:?}", self.state, self.buf);
         match self.state {
             State::Idle => {
                 // The minimal buffer length that is required to identify all
@@ -175,7 +179,7 @@ impl IngressManager {
                         self.state = State::ReceivingResponse;
                         self.buf_incomplete = false;
                         #[cfg(feature = "logging")]
-                        log::trace!("Ingress: Switching to state ReceivingResponse");
+                        log::trace!("Switching to state ReceivingResponse");
                     }
 
                 // Echo is currently required
@@ -201,6 +205,8 @@ impl IngressManager {
                 // with "AT" or "+") can be ignored. Clear the buffer, but only if we can
                 // ensure that we don't accidentally break a valid response.
                 } else if self.buf_incomplete || self.buf.len() > min_length {
+                    #[cfg(feature = "logging")]
+                    log::trace!("Clearing buffer with invalid response");
                     self.buf.clear();
                     self.buf_incomplete = true;
                 }
@@ -240,7 +246,7 @@ impl IngressManager {
 
                 self.notify_response(resp);
                 #[cfg(feature = "logging")]
-                log::trace!("Ingress: Switching to state Idle");
+                log::trace!("Switching to state Idle");
                 self.state = State::Idle;
             }
         }


### PR DESCRIPTION
Log incoming messages on DEBUG level once they're complete (both echo responses and URCs).

Invalid messages are only visible in TRACE level.

Logs filtered by DEBUG+ level can look like this:

```
[2020-03-14T22:17:35Z DEBUG atat::client] Sending command: "AT\r\n"
[2020-03-14T22:17:35Z DEBUG atat::ingress_manager] Received response: Ok("")
[2020-03-14T22:17:35Z DEBUG atat::client] Sending command: "AT+GMR\r\n"
[2020-03-14T22:17:35Z DEBUG atat::ingress_manager] Received response: Ok("AT version:1.1.0.0(May 11 2016 18:09:56)\r\nSDK version:1.5.4(baaeaebb)\r\ncompile time:May 20 2016 15:08:19")
[2020-03-14T22:17:35Z DEBUG atat::client] Sending command: "AT+RST\r\n"
[2020-03-14T22:17:35Z DEBUG atat::ingress_manager] Received response: Ok("")
```

Based on #27, merge that first! (That's why this PR is still marked as draft.)