### PR TITLE
Correctly handle whitespaces between command an params

### DIFF
--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -479,7 +479,6 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        self.eat_char();
         Ok(visitor.visit_seq(SeqAccess::new(self))?)
     }
 


### PR DESCRIPTION
Correctly handle whitespaces between command an params, eg '+CWMODE_CUR:1' vs 'CWMODE_CUR: 1'

Fixes #29 