### PR TITLE
Extract queue types into separate module

### DIFF
--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -1,18 +1,9 @@
-use heapless::{
-    consts,
-    spsc::{Consumer, Producer},
-    String,
-};
-
 use embedded_hal::{serial, timer::CountDown};
 
 use crate::error::Error;
+use crate::queues::{ComProducer, ResConsumer, UrcConsumer};
 use crate::traits::{AtatClient, AtatCmd, AtatUrc};
 use crate::{Command, Config, Mode};
-
-type ResConsumer = Consumer<'static, Result<String<consts::U256>, Error>, consts::U5, u8>;
-type UrcConsumer = Consumer<'static, String<consts::U64>, consts::U10, u8>;
-type ComProducer = Producer<'static, Command, consts::U3, u8>;
 
 #[derive(Debug, PartialEq)]
 enum ClientState {
@@ -30,10 +21,16 @@ where
     Tx: serial::Write<u8>,
     T: CountDown,
 {
+    /// Serial writer
     tx: Tx,
+
+    /// The response consumer receives responses from the ingress manager
     res_c: ResConsumer,
+    /// The URC consumer receives URCs from the ingress manager
     urc_c: UrcConsumer,
+    /// The command producer can send commands to the ingress manager
     com_p: ComProducer,
+
     state: ClientState,
     timer: T,
     config: Config,

--- a/atat/src/ingress_manager.rs
+++ b/atat/src/ingress_manager.rs
@@ -1,16 +1,8 @@
-use heapless::{
-    consts,
-    spsc::{Consumer, Producer},
-    ArrayLength, String,
-};
+use heapless::{consts, ArrayLength, String};
 
 use crate::error::Error;
-use crate::Command;
-use crate::Config;
-
-type ResProducer = Producer<'static, Result<String<consts::U256>, Error>, consts::U5, u8>;
-type UrcProducer = Producer<'static, String<consts::U64>, consts::U10, u8>;
-type ComConsumer = Consumer<'static, Command, consts::U3, u8>;
+use crate::queues::{ComConsumer, ResProducer, UrcProducer};
+use crate::{Command, Config};
 
 fn get_line<L: ArrayLength<u8>, I: ArrayLength<u8>>(
     buf: &mut String<I>,
@@ -61,8 +53,11 @@ pub struct IngressManager {
     /// with an incomplete response.
     buf_incomplete: bool,
 
+    /// The response producer sends responses to the client
     res_p: ResProducer,
+    /// The URC producer sends URCs to the client
     urc_p: UrcProducer,
+    /// The command consumer receives commands from the client
     com_c: ComConsumer,
 
     /// Current processing state.

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -185,18 +185,20 @@ extern crate void;
 mod client;
 mod error;
 mod ingress_manager;
+mod queues;
 mod traits;
-
-pub use self::client::Client;
-pub use self::error::Error;
-pub use self::ingress_manager::IngressManager;
-pub use self::traits::{AtatClient, AtatCmd, AtatResp, AtatUrc};
 
 #[cfg(feature = "derive")]
 pub use atat_derive;
 
 use embedded_hal::{serial, timer::CountDown};
-use heapless::{consts, spsc::Queue, String};
+use heapless::spsc::Queue;
+
+pub use self::client::Client;
+pub use self::error::Error;
+pub use self::ingress_manager::IngressManager;
+use self::queues::{ComQueue, ResQueue, UrcQueue};
+pub use self::traits::{AtatClient, AtatCmd, AtatResp, AtatUrc};
 
 pub mod prelude {
     //! The prelude is a collection of all the traits in this crate
@@ -289,9 +291,6 @@ impl Config {
     }
 }
 
-type ResQueue = Queue<Result<String<consts::U256>, error::Error>, consts::U5, u8>;
-type UrcQueue = Queue<String<consts::U64>, consts::U10, u8>;
-type ComQueue = Queue<Command, consts::U3, u8>;
 type ClientParser<Tx, T> = (Client<Tx, T>, IngressManager);
 
 /// Create a new Atat client instance.

--- a/atat/src/queues.rs
+++ b/atat/src/queues.rs
@@ -1,0 +1,35 @@
+//! Type definitions for the queues used in this crate.
+
+use heapless::spsc::{Consumer, Producer, Queue};
+use heapless::{consts, String};
+
+pub use crate::error::Error;
+pub use crate::Command;
+
+// Queue capacities
+type ComCapacity = consts::U3;
+type ResCapacity = consts::U5;
+type UrcCapacity = consts::U10;
+
+// Queue item types
+type ComItem = Command;
+type ResItem = Result<String<consts::U256>, Error>;
+type UrcItem = String<consts::U64>;
+
+// Note: We could create a simple macro to define producer, consumer and queue,
+// but that would probably be harder to read than just the plain definitions.
+
+// Consumers
+pub(crate) type ComConsumer = Consumer<'static, ComItem, ComCapacity, u8>;
+pub(crate) type ResConsumer = Consumer<'static, ResItem, ResCapacity, u8>;
+pub(crate) type UrcConsumer = Consumer<'static, UrcItem, UrcCapacity, u8>;
+
+// Producers
+pub(crate) type ComProducer = Producer<'static, ComItem, ComCapacity, u8>;
+pub(crate) type ResProducer = Producer<'static, ResItem, ResCapacity, u8>;
+pub(crate) type UrcProducer = Producer<'static, UrcItem, UrcCapacity, u8>;
+
+// Queues
+pub(crate) type ComQueue = Queue<ComItem, ComCapacity, u8>;
+pub(crate) type ResQueue = Queue<ResItem, ResCapacity, u8>;
+pub(crate) type UrcQueue = Queue<UrcItem, UrcCapacity, u8>;


### PR DESCRIPTION
Some refactoring. The types spread across the modules were a bit difficult to grasp.