### PR TITLE
Add support for custom URC matchers

### DIFF
--- a/atat/examples/cortex-m-rt.rs
+++ b/atat/examples/cortex-m-rt.rs
@@ -31,7 +31,7 @@ use heapless::{consts, spsc::Queue, String};
 
 use crate::rt::entry;
 
-static mut INGRESS: Option<atat::IngressManager> = None;
+static mut INGRESS: Option<atat::IngressManager<atat::NoopUrcMatcher>> = None;
 static mut RX: Option<Rx<USART2>> = None;
 
 #[entry]
@@ -75,7 +75,7 @@ fn main() -> ! {
     serial.listen(Rxne);
 
     let (tx, rx) = serial.split();
-    let (mut client, ingress) = atat::new(tx, at_timer, atat::Config::new(atat::Mode::Timeout));
+    let (mut client, ingress) = atat::new(tx, at_timer, atat::Config::new(atat::Mode::Timeout), None);
 
     unsafe { INGRESS = Some(ingress) };
     unsafe { RX = Some(rx) };

--- a/atat/examples/rtfm.rs
+++ b/atat/examples/rtfm.rs
@@ -33,7 +33,7 @@ use heapless::{consts, spsc::Queue, String};
 #[app(device = hal::pac, peripherals = true, monotonic = rtfm::cyccnt::CYCCNT)]
 const APP: () = {
     struct Resources {
-        ingress: atat::IngressManager,
+        ingress: atat::IngressManager<atat::NoopUrcMatcher>,
         rx: Rx<USART2>,
     }
 
@@ -77,7 +77,7 @@ const APP: () = {
         serial.listen(Rxne);
 
         let (tx, rx) = serial.split();
-        let (mut client, ingress) = atat::new(tx, timer, atat::Config::new(atat::Mode::Timeout));
+        let (mut client, ingress) = atat::new(tx, timer, atat::Config::new(atat::Mode::Timeout), None);
 
         ctx.spawn.at_loop().unwrap();
 

--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -158,6 +158,7 @@ mod test {
     use super::*;
     use crate as atat;
     use crate::atat_derive::{AtatCmd, AtatResp, AtatUrc};
+    use crate::queues;
     use heapless::{consts, spsc::Queue, String, Vec};
     use nb;
     use serde;
@@ -307,21 +308,19 @@ mod test {
 
     macro_rules! setup {
         ($config:expr) => {{
-            static mut REQ_Q: Queue<Result<String<consts::U256>, Error>, consts::U5, u8> =
-                Queue(heapless::i::Queue::u8());
-            let (p, c) = unsafe { REQ_Q.split() };
-            static mut URC_Q: Queue<String<consts::U256>, consts::U10, u8> =
-                Queue(heapless::i::Queue::u8());
+            static mut RES_Q: queues::ResQueue = Queue(heapless::i::Queue::u8());
+            let (res_p, res_c) = unsafe { RES_Q.split() };
+            static mut URC_Q: queues::UrcQueue = Queue(heapless::i::Queue::u8());
             let (urc_p, urc_c) = unsafe { URC_Q.split() };
-            static mut COM_Q: Queue<Command, consts::U3, u8> = Queue(heapless::i::Queue::u8());
+            static mut COM_Q: queues::ComQueue = Queue(heapless::i::Queue::u8());
             let (com_p, _com_c) = unsafe { COM_Q.split() };
 
             let timer = CdMock { time: 0 };
 
             let tx_mock = TxMock::new(String::new());
             let client: Client<TxMock, CdMock> =
-                Client::new(tx_mock, c, urc_c, com_p, timer, $config);
-            (client, p, urc_p)
+                Client::new(tx_mock, res_c, urc_c, com_p, timer, $config);
+            (client, res_p, urc_p)
         }};
     }
 

--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -310,7 +310,7 @@ mod test {
             static mut REQ_Q: Queue<Result<String<consts::U256>, Error>, consts::U5, u8> =
                 Queue(heapless::i::Queue::u8());
             let (p, c) = unsafe { REQ_Q.split() };
-            static mut URC_Q: Queue<String<consts::U64>, consts::U10, u8> =
+            static mut URC_Q: Queue<String<consts::U256>, consts::U10, u8> =
                 Queue(heapless::i::Queue::u8());
             let (urc_p, urc_c) = unsafe { URC_Q.split() };
             static mut COM_Q: Queue<Command, consts::U3, u8> = Queue(heapless::i::Queue::u8());
@@ -509,7 +509,7 @@ mod test {
         let (mut client, _, mut urc_p) = setup!(Config::new(Mode::NonBlocking));
 
         urc_p
-            .enqueue(String::<consts::U64>::from("+UMWI: 0, 1"))
+            .enqueue(String::<consts::U256>::from("+UMWI: 0, 1"))
             .unwrap();
 
         assert_eq!(client.state, ClientState::Idle);

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -7,7 +7,12 @@
 //!
 //! This can be simplified alot using the [`atat_derive`] crate!
 //!
+//! [`AtatCmd`]: trait.AtatCmd.html
+//! [`AtatResp`]: trait.AtatResp.html
+//! [`atat_derive`]: ../atat_derive/index.html
+//!
 //! # Examples
+//!
 //! ### Command and response example without atat_derive:
 //! ```
 //! pub struct SetGreetingText<'a> {
@@ -196,7 +201,7 @@ use heapless::{consts, spsc::Queue};
 
 pub use self::client::Client;
 pub use self::error::Error;
-pub use self::ingress_manager::{DefaultUrcHandler, IngressManager, UrcHandler, UrcHandlerResult};
+pub use self::ingress_manager::{IngressManager, NoopUrcMatcher, UrcMatcher, UrcMatcherResult};
 use self::queues::{ComQueue, ResQueue, UrcQueue};
 pub use self::traits::{AtatClient, AtatCmd, AtatResp, AtatUrc};
 
@@ -307,13 +312,13 @@ pub fn new<Tx, T, U>(
     serial_tx: Tx,
     timer: T,
     config: Config,
-    custom_urc_handler: Option<U>,
+    custom_urc_matcher: Option<U>,
 ) -> ClientParser<Tx, T, U>
 where
     Tx: serial::Write<u8>,
     T: CountDown,
     T::Time: From<u32>,
-    U: UrcHandler<MaxLen = consts::U256>,
+    U: UrcMatcher<MaxLen = consts::U256>,
 {
     static mut RES_QUEUE: ResQueue = Queue(heapless::i::Queue::u8());
     static mut URC_QUEUE: UrcQueue = Queue(heapless::i::Queue::u8());
@@ -321,7 +326,7 @@ where
     let (res_p, res_c) = unsafe { RES_QUEUE.split() };
     let (urc_p, urc_c) = unsafe { URC_QUEUE.split() };
     let (com_p, com_c) = unsafe { COM_QUEUE.split() };
-    let parser = IngressManager::new(res_p, urc_p, com_c, config, custom_urc_handler);
+    let parser = IngressManager::new(res_p, urc_p, com_c, config, custom_urc_matcher);
     let client = Client::new(serial_tx, res_c, urc_c, com_p, timer, config);
 
     (client, parser)

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -192,11 +192,11 @@ mod traits;
 pub use atat_derive;
 
 use embedded_hal::{serial, timer::CountDown};
-use heapless::spsc::Queue;
+use heapless::{consts, spsc::Queue};
 
 pub use self::client::Client;
 pub use self::error::Error;
-pub use self::ingress_manager::IngressManager;
+pub use self::ingress_manager::{DefaultUrcHandler, IngressManager, UrcHandler, UrcHandlerResult};
 use self::queues::{ComQueue, ResQueue, UrcQueue};
 pub use self::traits::{AtatClient, AtatCmd, AtatResp, AtatUrc};
 
@@ -293,7 +293,7 @@ impl Config {
     }
 }
 
-type ClientParser<Tx, T> = (Client<Tx, T>, IngressManager);
+type ClientParser<Tx, T, U> = (Client<Tx, T>, IngressManager<U>);
 
 /// Create a new Atat client instance.
 ///
@@ -303,11 +303,17 @@ type ClientParser<Tx, T> = (Client<Tx, T>, IngressManager);
 ///
 /// [serialwrite]: ../embedded_hal/serial/trait.Write.html
 /// [timercountdown]: ../embedded_hal/timer/trait.CountDown.html
-pub fn new<Tx, T>(serial_tx: Tx, timer: T, config: Config) -> ClientParser<Tx, T>
+pub fn new<Tx, T, U>(
+    serial_tx: Tx,
+    timer: T,
+    config: Config,
+    custom_urc_handler: Option<U>,
+) -> ClientParser<Tx, T, U>
 where
     Tx: serial::Write<u8>,
     T: CountDown,
     T::Time: From<u32>,
+    U: UrcHandler<MaxLen = consts::U256>,
 {
     static mut RES_QUEUE: ResQueue = Queue(heapless::i::Queue::u8());
     static mut URC_QUEUE: UrcQueue = Queue(heapless::i::Queue::u8());
@@ -315,7 +321,7 @@ where
     let (res_p, res_c) = unsafe { RES_QUEUE.split() };
     let (urc_p, urc_c) = unsafe { URC_QUEUE.split() };
     let (com_p, com_c) = unsafe { COM_QUEUE.split() };
-    let parser = IngressManager::new(res_p, urc_p, com_c, config);
+    let parser = IngressManager::new(res_p, urc_p, com_c, config, custom_urc_handler);
     let client = Client::new(serial_tx, res_c, urc_c, com_p, timer, config);
 
     (client, parser)

--- a/atat/src/queues.rs
+++ b/atat/src/queues.rs
@@ -14,7 +14,7 @@ type UrcCapacity = consts::U10;
 // Queue item types
 type ComItem = Command;
 type ResItem = Result<String<consts::U256>, Error>;
-type UrcItem = String<consts::U64>;
+type UrcItem = String<consts::U256>;
 
 // Note: We could create a simple macro to define producer, consumer and queue,
 // but that would probably be harder to read than just the plain definitions.


### PR DESCRIPTION
This was very tricky, but here's a suggestion for how custom URC handlers could be implemented.

Unfortunately this requires a type parameter for the `IngressManager` even if no custom URC handler is specified :confused: I added a dummy `DefaultUrcHandler` that can be used in those cases. We could offer some wrapper types that make this easier for the users by using `DefaultUrcHandler` by default.

PR might need some cleanup, but what do you think about the general direction? Best place to see how it works is the `custom_urc_handler` test.

Attempts to fix #33.

This also bumps the max size for URCs to 256 bytes.