### PR TITLE
Create ClientBuilder and hide UrcMatcher type

### DIFF
--- a/atat/examples/cortex-m-rt.rs
+++ b/atat/examples/cortex-m-rt.rs
@@ -75,7 +75,8 @@ fn main() -> ! {
     serial.listen(Rxne);
 
     let (tx, rx) = serial.split();
-    let (mut client, ingress) = atat::new(tx, at_timer, atat::Config::new(atat::Mode::Timeout), None);
+    let (mut client, ingress) =
+        atat::ClientBuilder::new(tx, at_timer, atat::Config::new(atat::Mode::Timeout)).build();
 
     unsafe { INGRESS = Some(ingress) };
     unsafe { RX = Some(rx) };

--- a/atat/examples/rtfm.rs
+++ b/atat/examples/rtfm.rs
@@ -77,7 +77,8 @@ const APP: () = {
         serial.listen(Rxne);
 
         let (tx, rx) = serial.split();
-        let (mut client, ingress) = atat::new(tx, timer, atat::Config::new(atat::Mode::Timeout), None);
+        let (mut client, ingress) =
+            atat::ClientBuilder::new(tx, timer, atat::Config::new(atat::Mode::Timeout)).build();
 
         ctx.spawn.at_loop().unwrap();
 

--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -15,7 +15,12 @@ enum ClientState {
 /// userfacing side. The client is decoupled from the ingress-manager through
 /// some spsc queue consumers, where any received responses can be dequeued. The
 /// Client also has an spsc producer, to allow signaling commands like
-/// 'clearBuffer' to the ingress-manager.
+/// `clearBuffer` to the ingress-manager.
+///
+/// Don't create a `Client` instance directly. Instead, use the
+/// [`ClientBuilder`].
+///
+/// [`ClientBuilder`]: struct.ClientBuilder.html
 pub struct Client<Tx, T>
 where
     Tx: serial::Write<u8>,

--- a/atat/src/ingress_manager.rs
+++ b/atat/src/ingress_manager.rs
@@ -141,7 +141,7 @@ impl UrcMatcher for NoopUrcMatcher {
     }
 }
 
-pub struct IngressManager<U> {
+pub struct IngressManager<U: UrcMatcher = NoopUrcMatcher> {
     /// Buffer holding incoming bytes.
     buf: String<consts::U256>,
     /// A flag that is set to `true` when the buffer is cleared
@@ -167,11 +167,17 @@ pub struct IngressManager<U> {
     custom_urc_matcher: Option<U>,
 }
 
+impl IngressManager<NoopUrcMatcher> {
+    pub fn new(res_p: ResProducer, urc_p: UrcProducer, com_c: ComConsumer, config: Config) -> Self {
+        Self::with_custom_urc_matcher(res_p, urc_p, com_c, config, None)
+    }
+}
+
 impl<U> IngressManager<U>
 where
     U: UrcMatcher<MaxLen = consts::U256>,
 {
-    pub fn new(
+    pub fn with_custom_urc_matcher(
         res_p: ResProducer,
         urc_p: UrcProducer,
         com_c: ComConsumer,
@@ -474,7 +480,7 @@ mod test {
             static mut COM_Q: Queue<Command, consts::U3, u8> = Queue(heapless::i::Queue::u8());
             let (_com_p, com_c) = unsafe { COM_Q.split() };
             (
-                IngressManager::new(req_p, urc_p, com_c, $config, $urch),
+                IngressManager::with_custom_urc_matcher(req_p, urc_p, com_c, $config, $urch),
                 req_c,
                 urc_c,
             )
@@ -736,7 +742,10 @@ mod test {
         struct MyUrcMatcher {}
         impl UrcMatcher for MyUrcMatcher {
             type MaxLen = consts::U256;
-            fn process(&mut self, buf: &mut String<consts::U256>) -> UrcMatcherResult<Self::MaxLen> {
+            fn process(
+                &mut self,
+                buf: &mut String<consts::U256>,
+            ) -> UrcMatcherResult<Self::MaxLen> {
                 if buf.starts_with("+match") {
                     let data = buf.clone();
                     buf.truncate(0);


### PR DESCRIPTION
- The IngressManager now has a default type parameter for the
  UrcMatcher, this lets you omit the parameter in some cases
- There are two methods on the `IngressManager`: `new` and
  `with_custom_urc_matcher`. This way the user does not need to provide
  a type parameter for the `UrcMatcher` at all when not using this
  feature, Rust can automatically derive the type.
- To improve ergonomics on the top-level, the `atat::new` factory
  function has now been replaced with a `ClientBuilder`.

Thanks @gandro for providing the API design idea with the default type parameter!