### PR TITLE
Refactor ingress buffer to Vec<u8>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "as-slice"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be6b7e95ac49d753f19cab5a825dea99a1149a04e4e3230b33ae16e120954c04"
+checksum = "37dfb65bc03b2bc85ee827004f14a6817e04160e3b1a28931986a666a9290e70"
 dependencies = [
  "generic-array 0.12.3",
  "generic-array 0.13.2",
@@ -29,7 +29,6 @@ dependencies = [
  "cortex-m-rt",
  "cortex-m-rtfm",
  "embedded-hal",
- "embedded-hal-mock",
  "heapless",
  "log",
  "nb",
@@ -38,7 +37,6 @@ dependencies = [
  "serde_at",
  "serde_repr",
  "stm32l4xx-hal",
- "ufmt",
  "void",
 ]
 
@@ -46,12 +44,10 @@ dependencies = [
 name = "atat_derive"
 version = "0.3.0"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
  "quote",
  "serde_at",
  "syn",
- "ufmt",
 ]
 
 [[package]]
@@ -158,16 +154,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "embedded-hal-mock"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22e3e0ab5455a3eb25072d53fe6c00e359282bd660ab58ec7d5541a68fa8b4e"
-dependencies = [
- "embedded-hal",
- "nb",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,14 +182,14 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b591a0032f114b7a77d4fbfab452660c553055515b7d7ece355db080d19087"
+version = "0.5.4"
+source = "git+https://github.com/japaric/heapless.git#75bcd7e496e5a1b74983c799ed83b61be33db7f4"
 dependencies = [
  "as-slice",
  "generic-array 0.13.2",
  "hash32",
  "serde",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -237,56 +223,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de96540e0ebde571dc55c73d60ef407c653844e6f9a1e2fdbd40c07b9252d812"
 
 [[package]]
-name = "proc-macro-error"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052b3c9af39c7e5e94245f820530487d19eb285faedcb40e0c3275132293f242"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d175bef481c7902e63e3165627123fff3502f06ac043d3ef42d08c1246da9253"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
- "syn-mid",
-]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.8"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
+checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+checksum = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -324,17 +273,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,9 +289,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.104"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+checksum = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
 
 [[package]]
 name = "serde_at"
@@ -367,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.104"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
+checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -395,9 +333,9 @@ checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "stm32l4"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769f6c1c26a76d1554473b21039e1233dd1d02a0262f23f5161150c2dcf2f538"
+checksum = "f51619cacd2de4a393c6d2bf168ab12dd87d92e5584793bfefa876ab39aff663"
 dependencies = [
  "bare-metal",
  "cortex-m",
@@ -408,12 +346,13 @@ dependencies = [
 [[package]]
 name = "stm32l4xx-hal"
 version = "0.5.0"
-source = "git+https://github.com/stm32-rs/stm32l4xx-hal#a0069673886199c2974990eff54d73ce315a5e74"
+source = "git+https://github.com/stm32-rs/stm32l4xx-hal#d3d4382c6d9bd79ac23aadc4c868c30cdd2bc9f7"
 dependencies = [
  "as-slice",
  "cast",
  "cortex-m",
  "embedded-hal",
+ "generic-array 0.13.2",
  "nb",
  "stable_deref_trait",
  "stm32l4",
@@ -422,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
+checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -432,50 +371,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn-mid"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "typenum"
-version = "1.11.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
-
-[[package]]
-name = "ufmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7ecea7ef79d3f8f878eee614afdf5256475c63ad76139d4da6125617c784a0"
-dependencies = [
- "proc-macro-hack",
- "ufmt-macros",
- "ufmt-write",
-]
-
-[[package]]
-name = "ufmt-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed813e34a2bfa9dc58ee2ed8c8314d25e6d70c911486d64b8085cb695cfac069"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "ufmt-write"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
+checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,8 +182,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.5.4"
-source = "git+https://github.com/japaric/heapless.git#75bcd7e496e5a1b74983c799ed83b61be33db7f4"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73a8a2391a3bc70b31f60e7a90daa5755a360559c0b6b9c5cfc0fee482362dc0"
 dependencies = [
  "as-slice",
  "generic-array 0.13.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,6 @@ members = [
     "atat_derive",
     "atat",
 ]
+
+[patch.crates-io]
+heapless = { git = "https://github.com/japaric/heapless.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,3 @@ members = [
     "atat_derive",
     "atat",
 ]
-
-[patch.crates-io]
-heapless = { git = "https://github.com/japaric/heapless.git" }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
-# `AT Parser`
+<div>
+  <img style="vertical-align:middle; padding-bottom: 20px; padding-right: 40px;"  src="https://w7.pngwing.com/pngs/154/828/png-transparent-star-wars-patent-all-terrain-armored-transport-printmaking-atat-uuml-rk-monochrome-film-mecha.png" alt="ATAT" width="150" />
+  <span style="font-size: 40px;">ATAT</span>
+</div>
+
+> no_std crate for parsing AT commands
 
 ![CI][workflow]
 [![Crates.io Version][crates-io-badge]][crates-io]
 [![Crates.io Downloads][crates-io-download-badge]][crates-io-download]
 [![chat][chat-badge]][chat]
+
+---
 
 A driver support crate for AT-command based serial modules, using the [embedded-hal] traits.
 

--- a/atat/Cargo.toml
+++ b/atat/Cargo.toml
@@ -21,7 +21,7 @@ maintenance = { status = "actively-developed" }
 embedded-hal = "^0.2"
 nb = "^0.1"
 void = { version = "^1", default-features = false }
-heapless = { version = "^0.5", features = ["serde"] }
+heapless = { version = "0.5.5", features = ["serde"] }
 serde_at = { path = "../serde_at", version = "^0.3.0"}
 atat_derive = { path = "../atat_derive", version = "^0.3.0", optional = true }
 serde = {version = "^1", default-features = false}

--- a/atat/Cargo.toml
+++ b/atat/Cargo.toml
@@ -18,16 +18,15 @@ name = "atat"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-embedded-hal = "0.2.3"
-nb = "0.1.2"
-ufmt = "0.1.0"
-void = { version = "1.0.2", default-features = false }
-heapless = { version = "0.5.3", features = ["serde"] }
+embedded-hal = "^0.2"
+nb = "^0.1"
+void = { version = "^1", default-features = false }
+heapless = { version = "^0.5", features = ["serde"] }
 serde_at = { path = "../serde_at", version = "^0.3.0"}
 atat_derive = { path = "../atat_derive", version = "^0.3.0", optional = true }
 serde = {version = "^1", default-features = false}
-serde_repr = "0.1.5"
-log = { version = "0.4", default-features = false, optional = true }
+serde_repr = "^0.1"
+log = { version = "^0.4", default-features = false, optional = true }
 
 [dev-dependencies]
 cortex-m = "0.6.2"
@@ -36,9 +35,6 @@ cortex-m-rtfm = "0.5.1"
 panic-halt = "0.2.0"
 stm32l4xx-hal = { git = "https://github.com/stm32-rs/stm32l4xx-hal", features = ["stm32l4x5", "rt"] }
 # stm32l4xx-hal = { version = "0.5.0", features = ["stm32l4x5", "rt"] }
-
-[target.'x86_64-unknown-linux-gnu'.dev-dependencies]
-embedded-hal-mock = "0.7.1"
 
 [features]
 default = ["derive"]

--- a/atat/examples/common/general/types.rs
+++ b/atat/examples/common/general/types.rs
@@ -1,9 +1,8 @@
 //! Argument and parameter types used by General Commands and Responses
 
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use ufmt::derive::uDebug;
 
-#[derive(uDebug, Clone, PartialEq, Serialize_repr, Deserialize_repr)]
+#[derive(Clone, PartialEq, Serialize_repr, Deserialize_repr)]
 #[repr(u8)]
 pub enum Snt {
     /// (default value): International Mobile station Equipment Identity (IMEI)
@@ -17,7 +16,7 @@ pub enum Snt {
 }
 
 /// Indicates the basic message indication type
-#[derive(uDebug, Clone, PartialEq, Serialize_repr, Deserialize_repr)]
+#[derive(Clone, PartialEq, Serialize_repr, Deserialize_repr)]
 #[repr(u8)]
 pub enum MessageIndicationType {
     /// • 1: Voice Message Waiting (third level method) or Voice Message Waiting on Line 1

--- a/atat/examples/common/mod.rs
+++ b/atat/examples/common/mod.rs
@@ -17,6 +17,6 @@ pub struct AT;
 
 #[derive(Clone, AtatUrc)]
 pub enum Urc {
-    #[at_urc("+UMWI")]
+    #[at_urc(b"+UMWI")]
     MessageWaitingIndication(general::urc::MessageWaitingIndication),
 }

--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -438,7 +438,9 @@ mod test {
         };
 
         let mut response = Vec::<u8, consts::U256>::new();
-        response.extend_from_slice(b"+CUN: 22,16,\"0123456789012345\"").unwrap();
+        response
+            .extend_from_slice(b"+CUN: 22,16,\"0123456789012345\"")
+            .unwrap();
         p.enqueue(Ok(response)).unwrap();
 
         let res_vec: Vec<u8, consts::U256> =
@@ -469,7 +471,9 @@ mod test {
         };
 
         let mut response = Vec::<u8, consts::U256>::new();
-        response.extend_from_slice(b"+CUN: 22,16,\"0123456789012345\"").unwrap();
+        response
+            .extend_from_slice(b"+CUN: 22,16,\"0123456789012345\"")
+            .unwrap();
         p.enqueue(Ok(response)).unwrap();
 
         assert_eq!(client.state, ClientState::Idle);
@@ -491,7 +495,9 @@ mod test {
         };
 
         let mut response = Vec::<u8, consts::U256>::new();
-        response.extend_from_slice(b"+CUN: \"0123456789012345\",22,16").unwrap();
+        response
+            .extend_from_slice(b"+CUN: \"0123456789012345\",22,16")
+            .unwrap();
         p.enqueue(Ok(response)).unwrap();
 
         assert_eq!(
@@ -511,9 +517,7 @@ mod test {
 
         let mut response = Vec::<u8, consts::U256>::new();
         response.extend_from_slice(b"+UMWI: 0, 1").unwrap();
-        urc_p
-            .enqueue(response)
-            .unwrap();
+        urc_p.enqueue(response).unwrap();
 
         assert_eq!(client.state, ClientState::Idle);
         assert!(client.check_urc::<Urc>().is_some());

--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -5,9 +5,6 @@ use crate::queues::{ComProducer, ResConsumer, UrcConsumer};
 use crate::traits::{AtatClient, AtatCmd, AtatUrc};
 use crate::{Command, Config, Mode};
 
-#[cfg(feature = "logging")]
-use crate::log_str;
-
 #[derive(Debug, PartialEq)]
 enum ClientState {
     Idle,
@@ -99,7 +96,7 @@ where
             block!(self.timer.wait()).ok();
             let cmd_buf = cmd.as_bytes();
             #[cfg(feature = "logging")]
-            log_str!(debug, "Sending command: {:?}", cmd_buf);
+            crate::log_str!(debug, "Sending command: {:?}", cmd_buf);
             for c in cmd_buf {
                 block!(self.tx.write(c)).map_err(|_e| Error::Write)?;
             }

--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -5,6 +5,9 @@ use crate::queues::{ComProducer, ResConsumer, UrcConsumer};
 use crate::traits::{AtatClient, AtatCmd, AtatUrc};
 use crate::{Command, Config, Mode};
 
+#[cfg(feature = "logging")]
+use crate::log_str;
+
 #[derive(Debug, PartialEq)]
 enum ClientState {
     Idle,
@@ -95,8 +98,8 @@ where
             // command
             block!(self.timer.wait()).ok();
             let cmd_buf = cmd.as_bytes();
-            // #[cfg(feature = "logging")]
-            // log::debug!("Sending command: {:?}", cmd_string.as_str());
+            #[cfg(feature = "logging")]
+            log_str!(debug, "Sending command: {:?}", cmd_buf);
             for c in cmd_buf {
                 block!(self.tx.write(c)).map_err(|_e| Error::Write)?;
             }

--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -94,11 +94,11 @@ where
             // `self.config.cmd_cooldown` ms have passed before sending a new
             // command
             block!(self.timer.wait()).ok();
-            let cmd_string = cmd.as_string();
-            #[cfg(feature = "logging")]
-            log::debug!("Sending command: {:?}", cmd_string.as_str());
-            for c in cmd_string.as_bytes() {
-                block!(self.tx.write(*c)).map_err(|_e| Error::Write)?;
+            let cmd_buf = cmd.as_bytes();
+            // #[cfg(feature = "logging")]
+            // log::debug!("Sending command: {:?}", cmd_string.as_str());
+            for c in cmd_buf {
+                block!(self.tx.write(c)).map_err(|_e| Error::Write)?;
             }
             block!(self.tx.flush()).map_err(|_e| Error::Write)?;
             self.state = ClientState::AwaitingResponse;
@@ -307,7 +307,7 @@ mod test {
 
     #[derive(Clone, AtatUrc)]
     pub enum Urc {
-        #[at_urc("+UMWI")]
+        #[at_urc(b"+UMWI")]
         MessageWaitingIndication(MessageWaitingIndication),
     }
 
@@ -338,7 +338,7 @@ mod test {
             rst: Some(ResetMode::DontReset),
         };
 
-        p.enqueue(Ok(String::<consts::U256>::from(""))).unwrap();
+        p.enqueue(Ok(Vec::<u8, consts::U256>::new())).unwrap();
 
         assert_eq!(client.state, ClientState::Idle);
         assert_eq!(client.send(&cmd), Ok(NoResponse));
@@ -350,7 +350,7 @@ mod test {
             "Wrong encoding of string"
         );
 
-        p.enqueue(Ok(String::<consts::U256>::from(""))).unwrap();
+        p.enqueue(Ok(Vec::<u8, consts::U256>::new())).unwrap();
 
         let cmd = Test2Cmd {
             fun: Functionality::DM,
@@ -395,7 +395,7 @@ mod test {
             rst: Some(ResetMode::DontReset),
         };
 
-        p.enqueue(Ok(String::<consts::U256>::from(""))).unwrap();
+        p.enqueue(Ok(Vec::<u8, consts::U256>::new())).unwrap();
 
         assert_eq!(client.state, ClientState::Idle);
         assert_eq!(client.send(&cmd), Ok(NoResponse));
@@ -418,7 +418,7 @@ mod test {
 
         assert_eq!(client.check_response(&cmd), Err(nb::Error::WouldBlock));
 
-        p.enqueue(Ok(String::<consts::U256>::from(""))).unwrap();
+        p.enqueue(Ok(Vec::<u8, consts::U256>::new())).unwrap();
 
         assert_eq!(client.state, ClientState::AwaitingResponse);
 
@@ -437,10 +437,9 @@ mod test {
             rst: Some(ResetMode::DontReset),
         };
 
-        p.enqueue(Ok(String::<consts::U256>::from(
-            "+CUN: 22,16,\"0123456789012345\"",
-        )))
-        .unwrap();
+        let mut response = Vec::<u8, consts::U256>::new();
+        response.extend_from_slice(b"+CUN: 22,16,\"0123456789012345\"").unwrap();
+        p.enqueue(Ok(response)).unwrap();
 
         let res_vec: Vec<u8, consts::U256> =
             "0123456789012345".as_bytes().iter().cloned().collect();
@@ -469,10 +468,9 @@ mod test {
             rst: Some(ResetMode::DontReset),
         };
 
-        p.enqueue(Ok(String::<consts::U256>::from(
-            "+CUN: 22,16,\"0123456789012345\"",
-        )))
-        .unwrap();
+        let mut response = Vec::<u8, consts::U256>::new();
+        response.extend_from_slice(b"+CUN: 22,16,\"0123456789012345\"").unwrap();
+        p.enqueue(Ok(response)).unwrap();
 
         assert_eq!(client.state, ClientState::Idle);
 
@@ -492,10 +490,9 @@ mod test {
             rst: Some(ResetMode::DontReset),
         };
 
-        p.enqueue(Ok(String::<consts::U256>::from(
-            "+CUN: \"0123456789012345\",22,16",
-        )))
-        .unwrap();
+        let mut response = Vec::<u8, consts::U256>::new();
+        response.extend_from_slice(b"+CUN: \"0123456789012345\",22,16").unwrap();
+        p.enqueue(Ok(response)).unwrap();
 
         assert_eq!(
             client.send(&cmd),
@@ -512,8 +509,10 @@ mod test {
     fn urc() {
         let (mut client, _, mut urc_p) = setup!(Config::new(Mode::NonBlocking));
 
+        let mut response = Vec::<u8, consts::U256>::new();
+        response.extend_from_slice(b"+UMWI: 0, 1").unwrap();
         urc_p
-            .enqueue(String::<consts::U256>::from("+UMWI: 0, 1"))
+            .enqueue(response)
             .unwrap();
 
         assert_eq!(client.state, ClientState::Idle);
@@ -531,8 +530,9 @@ mod test {
             rst: Some(ResetMode::DontReset),
         };
 
-        let resp: Result<String<consts::U256>, Error> =
-            Ok(String::<consts::U256>::from("+CUN: 22,16,22"));
+        let mut response = Vec::<u8, consts::U256>::new();
+        response.extend_from_slice(b"+CUN: 22,16,22").unwrap();
+        let resp: Result<Vec<u8, consts::U256>, Error> = Ok(response);
         p.enqueue(resp).unwrap();
 
         assert_eq!(client.state, ClientState::Idle);

--- a/atat/src/ingress_manager.rs
+++ b/atat/src/ingress_manager.rs
@@ -275,7 +275,10 @@ where
     /// received
     fn notify_response(&mut self, resp: Result<Vec<u8, consts::U256>, Error>) {
         #[cfg(feature = "logging")]
-        log::debug!("Received response: {:?}", &resp);
+        match &resp {
+            Ok(r) => log_str!(debug, "Received response: {:?}", r),
+            e @ Err(_) => log::debug!("Received response: {:?}", e)
+        }
         if self.res_p.ready() {
             self.res_p.enqueue(resp).ok();
         } else {
@@ -287,7 +290,8 @@ where
     /// received
     fn notify_urc(&mut self, resp: Vec<u8, consts::U256>) {
         #[cfg(feature = "logging")]
-        log::debug!("Received URC: {:?}", &resp);
+        log_str!(debug, "Received URC: {:?}", &resp);
+
         if self.urc_p.ready() {
             self.urc_p.enqueue(resp).ok();
         } else {

--- a/atat/src/ingress_manager.rs
+++ b/atat/src/ingress_manager.rs
@@ -366,19 +366,15 @@ where
         self.handle_com();
 
         // Trim leading whitespace
-        if let Some(c) = self.buf.get(0) {
-            if c == &self.line_term_char || c == &self.format_char {
-                let mut new_buf = Vec::new();
-                new_buf
-                    .extend_from_slice(self.buf.trim_start(&[
-                        b'\t',
-                        b' ',
-                        self.format_char,
-                        self.line_term_char,
-                    ]))
-                    .unwrap();
-                self.buf = new_buf;
-            }
+        if self.buf.starts_with(&[self.line_term_char]) || self.buf.starts_with(&[self.format_char])
+        {
+            self.buf = Vec::from_slice(self.buf.trim_start(&[
+                b'\t',
+                b' ',
+                self.format_char,
+                self.line_term_char,
+            ]))
+            .unwrap();
         }
 
         #[cfg(feature = "logging")]
@@ -589,29 +585,25 @@ mod test {
         at_pars.digest();
 
         {
-            let mut expectation = Vec::<_, consts::U256>::new();
-            expectation
-                .extend_from_slice(b"+USORD: 3,16,\"16 bytes of data\"\r\n")
-                .unwrap();
+            let expectation =
+                Vec::<_, consts::U256>::from_slice(b"+USORD: 3,16,\"16 bytes of data\"\r\n")
+                    .unwrap();
             assert_eq!(at_pars.buf, expectation);
         }
 
         at_pars.write(b"OK\r\n");
         {
-            let mut expectation = Vec::<_, consts::U256>::new();
-            expectation
-                .extend_from_slice(b"+USORD: 3,16,\"16 bytes of data\"\r\nOK\r\n")
-                .unwrap();
+            let expectation =
+                Vec::<_, consts::U256>::from_slice(b"+USORD: 3,16,\"16 bytes of data\"\r\nOK\r\n")
+                    .unwrap();
             assert_eq!(at_pars.buf, expectation);
         }
         at_pars.digest();
         assert_eq!(at_pars.buf, Vec::<_, consts::U256>::new());
         assert_eq!(at_pars.state, State::Idle);
         {
-            let mut expectation = Vec::<_, consts::U256>::new();
-            expectation
-                .extend_from_slice(b"+USORD: 3,16,\"16 bytes of data\"")
-                .unwrap();
+            let expectation =
+                Vec::<_, consts::U256>::from_slice(b"+USORD: 3,16,\"16 bytes of data\"").unwrap();
             assert_eq!(res_c.dequeue().unwrap(), Ok(expectation));
         }
     }
@@ -632,8 +624,7 @@ mod test {
         assert_eq!(at_pars.buf, Vec::<_, consts::U256>::new());
         assert_eq!(at_pars.state, State::Idle);
         {
-            let mut expectation = Vec::<_, consts::U256>::new();
-            expectation.extend_from_slice(b"AT version:1.1.0.0(May 11 2016 18:09:56)\r\nSDK version:1.5.4(baaeaebb)\r\ncompile time:May 20 2016 15:08:19").unwrap();
+            let expectation = Vec::<_, consts::U256>::from_slice(b"AT version:1.1.0.0(May 11 2016 18:09:56)\r\nSDK version:1.5.4(baaeaebb)\r\ncompile time:May 20 2016 15:08:19").unwrap();
             assert_eq!(res_c.dequeue().unwrap(), Ok(expectation));
         }
     }

--- a/atat/src/ingress_manager.rs
+++ b/atat/src/ingress_manager.rs
@@ -99,6 +99,16 @@ pub(crate) fn get_line<L: ArrayLength<u8>, I: ArrayLength<u8>>(
     }
 }
 
+#[cfg(feature = "logging")]
+macro_rules! log_str {
+    ($level:ident, $fmt:expr, $buf:expr) => {
+        match core::str::from_utf8(&$buf) {
+            Ok(s) => log::$level!($fmt, s),
+            Err(_) => log::$level!($fmt, $buf),
+        }
+    };
+}
+
 /// State of the IngressManager, used to distiguish URCs from solicited
 /// responses
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -292,7 +302,7 @@ where
                 Command::ClearBuffer => {
                     self.state = State::Idle;
                     #[cfg(feature = "logging")]
-                    log::debug!("Clearing buffer on timeout / {:?}", self.buf);
+                    log_str!(debug, "Clearing buffer on timeout / {:?}", &self.buf);
                     self.clear_buf(true);
                 }
                 Command::ForceState(state) => {
@@ -336,7 +346,7 @@ where
                 #[allow(unused)]
                 Some(r) => {
                     #[cfg(feature = "logging")]
-                    log::trace!("Cleared partial buffer, removed {:?}", r);
+                    log_str!(trace, "Cleared partial buffer, removed {:?}", r);
                 }
                 None => {
                     self.buf.clear();
@@ -371,7 +381,7 @@ where
         }
 
         #[cfg(feature = "logging")]
-        log::trace!("Digest / {:?} / {:?}", self.state, self.buf);
+        log_str!(trace, "Digest / {:?}", self.buf);
 
         match self.state {
             State::Idle => {

--- a/atat/src/ingress_manager.rs
+++ b/atat/src/ingress_manager.rs
@@ -17,7 +17,7 @@ impl SliceExt for [u8] {
 
         if let Some(first) = self.iter().position(is_not_whitespace) {
             if let Some(last) = self.iter().rposition(is_not_whitespace) {
-                &self[first..last + 1]
+                &self[first..=last]
             } else {
                 unreachable!();
             }

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -183,11 +183,6 @@
 #![cfg_attr(not(test), no_std)]
 // #![feature(test)]
 
-#[macro_use]
-extern crate nb;
-extern crate ufmt;
-extern crate void;
-
 mod client;
 mod error;
 mod ingress_manager;

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -216,6 +216,17 @@ pub mod prelude {
     pub use crate::AtatUrc as _atat_AtatUrc;
 }
 
+#[cfg(feature = "logging")]
+#[macro_export]
+macro_rules! log_str {
+    ($level:ident, $fmt:expr, $buf:expr) => {
+        match core::str::from_utf8(&$buf) {
+            Ok(s) => log::$level!($fmt, s),
+            Err(_) => log::$level!($fmt, $buf),
+        }
+    };
+}
+
 /// Whether the AT client should block while waiting responses or return early.
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Mode {

--- a/atat/src/queues.rs
+++ b/atat/src/queues.rs
@@ -1,7 +1,7 @@
 //! Type definitions for the queues used in this crate.
 
 use heapless::spsc::{Consumer, Producer, Queue};
-use heapless::{consts, String};
+use heapless::{consts, Vec};
 
 pub use crate::error::Error;
 pub use crate::Command;
@@ -13,8 +13,8 @@ type UrcCapacity = consts::U10;
 
 // Queue item types
 type ComItem = Command;
-type ResItem = Result<String<consts::U256>, Error>;
-type UrcItem = String<consts::U256>;
+type ResItem = Result<Vec<u8, consts::U256>, Error>;
+type UrcItem = Vec<u8, consts::U256>;
 
 // Note: We could create a simple macro to define producer, consumer and queue,
 // but that would probably be harder to read than just the plain definitions.

--- a/atat/src/traits.rs
+++ b/atat/src/traits.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
 use crate::Mode;
-use heapless::{ArrayLength, String};
+use heapless::{ArrayLength, Vec};
 
 pub trait AtatErr {}
 
@@ -23,7 +23,7 @@ pub trait AtatUrc {
     type Response;
 
     /// Parse the string response into a `Self::Response` instance.
-    fn parse(resp: &str) -> Result<Self::Response, Error>;
+    fn parse(resp: &[u8]) -> Result<Self::Response, Error>;
 }
 
 /// This trait needs to be implemented for every command type.
@@ -68,11 +68,11 @@ pub trait AtatCmd {
     /// The type of the response. Must implement the `AtatResp` trait.
     type Response: AtatResp;
 
-    /// Return the command as a heapless `String`.
-    fn as_string(&self) -> String<Self::CommandLen>;
+    /// Return the command as a heapless `Vec` of bytes.
+    fn as_bytes(&self) -> Vec<u8, Self::CommandLen>;
 
     /// Parse the string response into a `Self::Response` instance.
-    fn parse(&self, resp: &str) -> Result<Self::Response, Error>;
+    fn parse(&self, resp: &[u8]) -> Result<Self::Response, Error>;
 
     /// Whether or not this command can be aborted.
     fn can_abort(&self) -> bool {

--- a/atat/src/traits.rs
+++ b/atat/src/traits.rs
@@ -22,7 +22,7 @@ pub trait AtatUrc {
     /// The type of the response. Usually the enum this trait is implemented on.
     type Response;
 
-    /// Parse the string response into a `Self::Response` instance.
+    /// Parse the response into a `Self::Response` instance.
     fn parse(resp: &[u8]) -> Result<Self::Response, Error>;
 }
 
@@ -44,8 +44,8 @@ pub trait AtatUrc {
 ///     type CommandLen = heapless::consts::U64;
 ///     type Response = NoResponse;
 ///
-///     fn as_str(&self) -> String<Self::CommandLen> {
-///         let buf: String<Self::CommandLen> = String::new();
+///     fn as_bytes(&self) -> Vec<u8, Self::CommandLen> {
+///         let buf: Vec<u8, Self::CommandLen> = Vec::new();
 ///         write!(buf, "AT+CSGT={}", self.text);
 ///         buf
 ///     }
@@ -71,7 +71,7 @@ pub trait AtatCmd {
     /// Return the command as a heapless `Vec` of bytes.
     fn as_bytes(&self) -> Vec<u8, Self::CommandLen>;
 
-    /// Parse the string response into a `Self::Response` instance.
+    /// Parse the response into a `Self::Response` instance.
     fn parse(&self, resp: &[u8]) -> Result<Self::Response, Error>;
 
     /// Whether or not this command can be aborted.

--- a/atat_derive/Cargo.toml
+++ b/atat_derive/Cargo.toml
@@ -9,11 +9,9 @@ license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/atat_derive"
 
 [dependencies]
-ufmt = "0.1.0"
-quote = "1.0"
-syn = { version = "1.0", features = ["extra-traits","full"] }
-proc-macro2 = "1.0"
-proc-macro-error = "0.4"
+quote = "^1"
+syn = { version = "^1", features = ["extra-traits","full"] }
+proc-macro2 = "^1"
 serde_at = { path = "../serde_at", version = "^0.3.0"}
 
 [lib]

--- a/atat_derive/src/cmd.rs
+++ b/atat_derive/src/cmd.rs
@@ -194,29 +194,29 @@ fn generate_cmd_output(
             }
         }
 
-        #[automatically_derived]
-        #[cfg(feature = "use_ufmt")]
-        impl #impl_generics ufmt::uDebug for #name #ty_generics #where_clause {
-            fn fmt<W>(&self, f: &mut ufmt::Formatter<'_, W>) -> core::result::Result<(), W::Error>
-            where
-                W: ufmt::uWrite + ?Sized,
-            {
-                use atat::AtatCmd as _;
-                f.write_str(&self.as_string())
-            }
-        }
+        // #[automatically_derived]
+        // #[cfg(feature = "use_ufmt")]
+        // impl #impl_generics ufmt::uDebug for #name #ty_generics #where_clause {
+        //     fn fmt<W>(&self, f: &mut ufmt::Formatter<'_, W>) -> core::result::Result<(), W::Error>
+        //     where
+        //         W: ufmt::uWrite + ?Sized,
+        //     {
+        //         use atat::AtatCmd as _;
+        //         f.write_str(&self.as_string())
+        //     }
+        // }
 
-        #[automatically_derived]
-        #[cfg(feature = "use_ufmt")]
-        impl #impl_generics ufmt::uDisplay for #name #ty_generics #where_clause {
-            fn fmt<W>(&self, f: &mut ufmt::Formatter<'_, W>) -> core::result::Result<(), W::Error>
-            where
-                W: ufmt::uWrite + ?Sized,
-            {
-                use atat::AtatCmd as _;
-                let c = self.as_string();
-                f.write_str(&c[0..c.len() - 2])
-            }
-        }
+        // #[automatically_derived]
+        // #[cfg(feature = "use_ufmt")]
+        // impl #impl_generics ufmt::uDisplay for #name #ty_generics #where_clause {
+        //     fn fmt<W>(&self, f: &mut ufmt::Formatter<'_, W>) -> core::result::Result<(), W::Error>
+        //     where
+        //         W: ufmt::uWrite + ?Sized,
+        //     {
+        //         use atat::AtatCmd as _;
+        //         let c = self.as_string();
+        //         f.write_str(&c[0..c.len() - 2])
+        //     }
+        // }
     })
 }

--- a/atat_derive/src/cmd.rs
+++ b/atat_derive/src/cmd.rs
@@ -193,30 +193,5 @@ fn generate_cmd_output(
                 serde::ser::SerializeStruct::end(serde_state)
             }
         }
-
-        // #[automatically_derived]
-        // #[cfg(feature = "use_ufmt")]
-        // impl #impl_generics ufmt::uDebug for #name #ty_generics #where_clause {
-        //     fn fmt<W>(&self, f: &mut ufmt::Formatter<'_, W>) -> core::result::Result<(), W::Error>
-        //     where
-        //         W: ufmt::uWrite + ?Sized,
-        //     {
-        //         use atat::AtatCmd as _;
-        //         f.write_str(&self.as_string())
-        //     }
-        // }
-
-        // #[automatically_derived]
-        // #[cfg(feature = "use_ufmt")]
-        // impl #impl_generics ufmt::uDisplay for #name #ty_generics #where_clause {
-        //     fn fmt<W>(&self, f: &mut ufmt::Formatter<'_, W>) -> core::result::Result<(), W::Error>
-        //     where
-        //         W: ufmt::uWrite + ?Sized,
-        //     {
-        //         use atat::AtatCmd as _;
-        //         let c = self.as_string();
-        //         f.write_str(&c[0..c.len() - 2])
-        //     }
-        // }
     })
 }

--- a/atat_derive/src/cmd.rs
+++ b/atat_derive/src/cmd.rs
@@ -130,11 +130,11 @@ fn generate_cmd_output(
         #[automatically_derived]
         impl #impl_generics atat::AtatCmd for #name #ty_generics #where_clause {
             type Response = #response;
-            type CommandLen = heapless::consts::U2048;
+            type CommandLen = ::heapless::consts::U2048;
 
-            fn as_string(&self) -> heapless::String<Self::CommandLen> {
-                let s: heapless::String<heapless::consts::#subcmd_len> = heapless::String::from(#cmd);
-                match serde_at::to_string(self, s, serde_at::SerializeOptions {
+            fn as_bytes(&self) -> ::heapless::Vec<u8, Self::CommandLen> {
+                let s: ::heapless::String<::heapless::consts::#subcmd_len> = ::heapless::String::from(#cmd);
+                match serde_at::to_vec(self, s, serde_at::SerializeOptions {
                     value_sep: #value_sep,
                     cmd_prefix: #cmd_prefix,
                     termination: #termination
@@ -144,8 +144,8 @@ fn generate_cmd_output(
                 }
             }
 
-            fn parse(&self, resp: &str) -> core::result::Result<#response, atat::Error> {
-                serde_at::from_str::<#response>(resp).map_err(|e| {
+            fn parse(&self, resp: &[u8]) -> core::result::Result<#response, atat::Error> {
+                serde_at::from_slice::<#response>(resp).map_err(|e| {
                     atat::Error::ParseString
                 })
             }

--- a/atat_derive/src/urc.rs
+++ b/atat_derive/src/urc.rs
@@ -78,11 +78,11 @@ fn generate_urc_output(
         impl #impl_generics atat::AtatUrc for #name #ty_generics #where_clause {
             type Response = #name;
 
-            fn parse(resp: &str) -> ::core::result::Result<Self::Response, atat::Error> {
-                if let Some(cmd) = resp.splitn(2, ':').next() {
-                    Ok(match cmd {
+            fn parse(resp: &[u8]) -> ::core::result::Result<Self::Response, atat::Error> {
+                if let Some(index) = resp.iter().position(|&x| x == b':') {
+                    Ok(match &resp[..index] {
                         #(
-                            #cmds => #name::#variant_names(serde_at::from_str::<#variant_field_types>(resp).map_err(|e| {
+                            #cmds => #name::#variant_names(serde_at::from_slice::<#variant_field_types>(resp).map_err(|e| {
                                 atat::Error::ParseString
                             })?),
                         )*

--- a/serde_at/Cargo.toml
+++ b/serde_at/Cargo.toml
@@ -11,7 +11,7 @@ name = "serde_at"
 version = "0.3.0"
 
 [dependencies]
-heapless = { version = "0.5.3", features = ["serde"] }
+heapless = { version = "^0.5", features = ["serde"] }
 log = "0.4.8"
 
 [dependencies.serde]

--- a/serde_at/Cargo.toml
+++ b/serde_at/Cargo.toml
@@ -11,7 +11,7 @@ name = "serde_at"
 version = "0.3.0"
 
 [dependencies]
-heapless = { version = "^0.5", features = ["serde"] }
+heapless = { version = "0.5.5", features = ["serde"] }
 log = "0.4.8"
 
 [dependencies.serde]

--- a/serde_at/src/de/seq.rs
+++ b/serde_at/src/de/seq.rs
@@ -20,25 +20,21 @@ impl<'a, 'de> de::SeqAccess<'de> for SeqAccess<'a, 'de> {
     where
         T: de::DeserializeSeed<'de>,
     {
-        match self
-            .de
-            .parse_whitespace()
-            .ok_or(Error::EofWhileParsingList)?
-        {
-            b',' => {
+        match self.de.parse_whitespace() {
+            Some(b',') => {
                 self.de.eat_char();
                 self.de
                     .parse_whitespace()
-                    .ok_or(Error::EofWhileParsingValue)?
+                    .ok_or(Error::EofWhileParsingValue)?;
             }
-            c => {
+            Some(_) => {
                 if self.first {
                     self.first = false;
-                    c
                 } else {
                     return Ok(None);
                 }
             }
+            None => {}
         };
 
         Ok(Some(seed.deserialize(&mut *self.de)?))


### PR DESCRIPTION
Refactor underlying receive buffer from String to Vec<u8>, to accomodate non-ascii character transfers (eg. binary data)

Fixes #39 