### PR TITLE
Add support for defmt logging

### DIFF
--- a/.github/workflows/grcov.yml
+++ b/.github/workflows/grcov.yml
@@ -39,8 +39,8 @@ jobs:
           args: --lib --no-fail-fast --all-features
         env:
           CARGO_INCREMENTAL: "0"
-          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
-          RUSTDOCFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
+          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=unwind -Zpanic_abort_tests"
+          RUSTDOCFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=unwind -Zpanic_abort_tests"
 
       - name: Generate coverage data
         id: grcov

--- a/README.md
+++ b/README.md
@@ -94,8 +94,14 @@ The following dependent crates provide platform-agnostic device drivers built on
 
 ## Features
 
- - `logging`: Disabled by default. Add log statements on various log levels to aid debugging.
  - `derive`: Enabled by default. Re-exports `atat_derive` to allow deriving `Atat__` traits.
+ - `log-logging`: Disabled by default. Enable log statements on various log levels to aid debugging. Powered by `log`.
+ - `defmt-default`: Disabled by default. Enable log statements at INFO, or TRACE, level and up, to aid debugging. Powered by `defmt`.
+ - `defmt-trace`: Disabled by default. Enable log statements at TRACE level and up, to aid debugging. Powered by `defmt`.
+ - `defmt-debug`: Disabled by default. Enable log statements at DEBUG level and up, to aid debugging. Powered by `defmt`.
+ - `defmt-info`: Disabled by default. Enable log statements at INFO level and up, to aid debugging. Powered by `defmt`.
+ - `defmt-warn`: Disabled by default. Enable log statements at WARN level and up, to aid debugging. Powered by `defmt`.
+ - `defmt-error`: Disabled by default. Enable log statements at ERROR level and up, to aid debugging. Powered by `defmt`.
 
 ## Chat / Getting Help
 

--- a/atat/Cargo.toml
+++ b/atat/Cargo.toml
@@ -33,12 +33,12 @@ defmt = { git = "https://github.com/knurling-rs/defmt", branch = "main", optiona
 [dev-dependencies]
 cortex-m = "0.6.3"
 cortex-m-rt = "0.6.12"
-cortex-m-rtic = "0.5.3"
+cortex-m-rtic = "0.5.4"
 panic-halt = "0.2.0"
 stm32l4xx-hal = { git = "https://github.com/stm32-rs/stm32l4xx-hal", features = ["stm32l4x5", "rt"] }
 
 [features]
-default = ["derive"]
+default = ["derive", "defmt-trace"]
 derive = ["atat_derive"]
 
 log-logging = ["log"]

--- a/atat/Cargo.toml
+++ b/atat/Cargo.toml
@@ -19,17 +19,19 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 embedded-hal = "^0.2"
-nb = "^0.1"
+nb = "^1"
 void = { version = "^1", default-features = false }
 heapless = { version = "0.5.5", features = ["serde"] }
 serde_at = { path = "../serde_at", version = "^0.4.3-alpha.0"}
 atat_derive = { path = "../atat_derive", version = "^0.4.3-alpha.0", optional = true }
 serde = {version = "^1", default-features = false}
-log = { version = "^0.4", default-features = false, optional = true }
 typenum = "^1"
 
+log = { version = "^0.4", default-features = false, optional = true }
+defmt = { git = "https://github.com/knurling-rs/defmt", branch = "main", optional = true }
+
 [dev-dependencies]
-cortex-m = "0.6.2"
+cortex-m = "0.6.3"
 cortex-m-rt = "0.6.12"
 cortex-m-rtic = "0.5.3"
 panic-halt = "0.2.0"
@@ -38,4 +40,12 @@ stm32l4xx-hal = { git = "https://github.com/stm32-rs/stm32l4xx-hal", features = 
 [features]
 default = ["derive"]
 derive = ["atat_derive"]
-logging = ["log"]
+
+log-logging = ["log"]
+
+defmt-default = ["defmt"]
+defmt-trace = ["defmt"]
+defmt-debug = ["defmt"]
+defmt-info = ["defmt"]
+defmt-warn = ["defmt"]
+defmt-error = ["defmt"]

--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -117,7 +117,21 @@ where
             // command
             nb::block!(self.timer.wait()).ok();
             let cmd_buf = cmd.as_bytes();
-            // log_str!(debug, "Sending command: {:?}", cmd_buf);
+
+            match core::str::from_utf8(&cmd_buf) {
+                Ok(s) => {
+                    #[cfg(not(feature = "log-logging"))]
+                    atat_log!(debug, "Sending command: {:str}", s);
+                    #[cfg(feature = "log-logging")]
+                    atat_log!(debug, "Sending command: {:?}", s);
+                }
+                Err(_) => atat_log!(
+                    debug,
+                    "Sending command: {:?}",
+                    core::convert::AsRef::<[u8]>::as_ref(&cmd_buf)
+                ),
+            };
+
             for c in cmd_buf {
                 nb::block!(self.tx.write(c)).map_err(|_e| Error::Write)?;
             }

--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -118,12 +118,13 @@ where
             nb::block!(self.timer.wait()).ok();
             let cmd_buf = cmd.as_bytes();
 
+            #[allow(clippy::single_match)]
             match core::str::from_utf8(&cmd_buf) {
-                Ok(s) => {
+                Ok(_s) => {
                     #[cfg(not(feature = "log-logging"))]
-                    atat_log!(debug, "Sending command: {:str}", s);
+                    atat_log!(debug, "Sending command: {:str}", _s);
                     #[cfg(feature = "log-logging")]
-                    atat_log!(debug, "Sending command: {:?}", s);
+                    atat_log!(debug, "Sending command: {:?}", _s);
                 }
                 Err(_) => atat_log!(
                     debug,

--- a/atat/src/error.rs
+++ b/atat/src/error.rs
@@ -1,6 +1,16 @@
 /// Errors returned by, or used within the crate
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "defmt_logging", derive(defmt::Format))]
+#[cfg_attr(
+    any(
+        feature = "defmt-default",
+        feature = "defmt-trace",
+        feature = "defmt-debug",
+        feature = "defmt-info",
+        feature = "defmt-warn",
+        feature = "defmt-error"
+    ),
+    derive(defmt::Format)
+)]
 pub enum Error {
     /// Serial read error
     Read,

--- a/atat/src/error.rs
+++ b/atat/src/error.rs
@@ -1,5 +1,6 @@
 /// Errors returned by, or used within the crate
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "defmt_logging", derive(defmt::Format))]
 pub enum Error {
     /// Serial read error
     Read,

--- a/atat/src/ingress_manager.rs
+++ b/atat/src/ingress_manager.rs
@@ -321,12 +321,13 @@ where
     /// Notify the client that an unsolicited response code (URC) has been
     /// received
     fn notify_urc(&mut self, resp: ByteVec<BufLen>) {
+        #[allow(clippy::single_match)]
         match core::str::from_utf8(&resp) {
-            Ok(s) => {
+            Ok(_s) => {
                 #[cfg(not(feature = "log-logging"))]
-                atat_log!(debug, "Received URC: {:str}", s);
+                atat_log!(debug, "Received URC: {:str}", _s);
                 #[cfg(feature = "log-logging")]
-                atat_log!(debug, "Received URC: {:?}", s);
+                atat_log!(debug, "Received URC: {:?}", _s);
             }
             Err(_) => atat_log!(
                 debug,
@@ -349,12 +350,13 @@ where
                 Command::ClearBuffer => {
                     self.state = State::Idle;
                     self.buf_incomplete = false;
+                    #[allow(clippy::single_match)]
                     match core::str::from_utf8(&self.buf) {
-                        Ok(s) => {
+                        Ok(_s) => {
                             #[cfg(not(feature = "log-logging"))]
-                            atat_log!(debug, "Clearing buffer on timeout / {:str}", s);
+                            atat_log!(debug, "Clearing buffer on timeout / {:str}", _s);
                             #[cfg(feature = "log-logging")]
-                            atat_log!(debug, "Clearing buffer on timeout / {:?}", s);
+                            atat_log!(debug, "Clearing buffer on timeout / {:?}", _s);
                         }
                         Err(_) => atat_log!(
                             debug,
@@ -403,12 +405,13 @@ where
             );
             #[allow(unused_variables)]
             if let Some(r) = removed {
+                #[allow(clippy::single_match)]
                 match core::str::from_utf8(&r) {
-                    Ok(s) => {
+                    Ok(_s) => {
                         #[cfg(not(feature = "log-logging"))]
-                        atat_log!(trace, "Cleared partial buffer, removed {:str}", s);
+                        atat_log!(trace, "Cleared partial buffer, removed {:str}", _s);
                         #[cfg(feature = "log-logging")]
-                        atat_log!(trace, "Cleared partial buffer, removed {:?}", s);
+                        atat_log!(trace, "Cleared partial buffer, removed {:?}", _s);
                     }
                     Err(_) => atat_log!(
                         trace,
@@ -442,12 +445,13 @@ where
             .unwrap();
         }
 
+        #[allow(clippy::single_match)]
         match core::str::from_utf8(&self.buf) {
-            Ok(s) => {
+            Ok(_s) => {
                 #[cfg(not(feature = "log-logging"))]
-                atat_log!(trace, "Digest / {:str}", s);
+                atat_log!(trace, "Digest / {:str}", _s);
                 #[cfg(feature = "log-logging")]
-                atat_log!(trace, "Digest / {:?}", s);
+                atat_log!(trace, "Digest / {:?}", _s);
             }
             Err(_) => atat_log!(
                 trace,

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -95,7 +95,7 @@
 //!
 //! ### Basic usage example (More available in examples folder):
 //! ```ignore
-//! 
+//!
 //! use cortex_m::asm;
 //! use hal::{
 //!     gpio::{
@@ -298,17 +298,30 @@ macro_rules! atat_log {
         defmt::$level!($($arg)+);
     }
 }
-#[cfg(not(any(
-    any(
-        feature = "defmt-default",
-        feature = "defmt-trace",
-        feature = "defmt-debug",
-        feature = "defmt-info",
-        feature = "defmt-warn",
-        feature = "defmt-error"
+#[cfg(any(
+    all(
+        any(
+            feature = "defmt-default",
+            feature = "defmt-trace",
+            feature = "defmt-debug",
+            feature = "defmt-info",
+            feature = "defmt-warn",
+            feature = "defmt-error"
+        ),
+        feature = "log-logging"
     ),
-    feature = "log-logging"
-)))]
+    not(any(
+        any(
+            feature = "defmt-default",
+            feature = "defmt-trace",
+            feature = "defmt-debug",
+            feature = "defmt-info",
+            feature = "defmt-warn",
+            feature = "defmt-error"
+        ),
+        feature = "log-logging"
+    ))
+))]
 #[macro_export]
 macro_rules! atat_log {
     ($level:ident, $($arg:tt)+) => {

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -95,7 +95,7 @@
 //!
 //! ### Basic usage example (More available in examples folder):
 //! ```ignore
-//!
+//! 
 //! use cortex_m::asm;
 //! use hal::{
 //!     gpio::{

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -254,16 +254,6 @@ pub mod prelude {
     pub use crate::AtatLen as _atat_AtatLen;
 }
 
-#[macro_export]
-macro_rules! log_str {
-    ($level:ident, $fmt:expr, $buf:expr) => {
-        match core::str::from_utf8(&$buf) {
-            Ok(_s) => atat_log!($level, $fmt, _s),
-            Err(_) => atat_log!($level, $fmt, $buf),
-        };
-    };
-}
-
 #[cfg(all(
     feature = "log-logging",
     not(any(

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -95,7 +95,7 @@
 //!
 //! ### Basic usage example (More available in examples folder):
 //! ```ignore
-//! 
+//!
 //! use cortex_m::asm;
 //! use hal::{
 //!     gpio::{
@@ -194,10 +194,14 @@
 //! ```
 //! # Optional Cargo Features
 //!
-//! - **`derive`** *(enabled by default)* — Enables and re-exports
-//!   [`atat_derive`].
-//! - **`logging`** *(disabled by default)* — Prints useful logging information,
-//!   including incoming and outgoing bytes on the `TRACE` level.
+//! - **`derive`** *(enabled by default)* - Re-exports [`atat_derive`] to allow deriving `Atat__` traits.
+//! - **`log-logging`** *(disabled by default)* - Enable log statements on various log levels to aid debugging. Powered by `log`.
+//! - **`defmt-default`** *(disabled by default)* - Enable log statements at INFO, or TRACE, level and up, to aid debugging. Powered by `defmt`.
+//! - **`defmt-trace`** *(disabled by default)* - Enable log statements at TRACE level and up, to aid debugging. Powered by `defmt`.
+//! - **`defmt-debug`** *(disabled by default)* - Enable log statements at DEBUG level and up, to aid debugging. Powered by `defmt`.
+//! - **`defmt-info`** *(disabled by default)* - Enable log statements at INFO level and up, to aid debugging. Powered by `defmt`.
+//! - **`defmt-warn`** *(disabled by default)* - Enable log statements at WARN level and up, to aid debugging. Powered by `defmt`.
+//! - **`defmt-error`** *(disabled by default)* - Enable log statements at ERROR level and up, to aid debugging. Powered by `defmt`.
 
 #![deny(rust_2018_compatibility)]
 #![deny(rust_2018_idioms)]
@@ -250,14 +254,65 @@ pub mod prelude {
     pub use crate::AtatLen as _atat_AtatLen;
 }
 
-#[cfg(feature = "logging")]
 #[macro_export]
 macro_rules! log_str {
     ($level:ident, $fmt:expr, $buf:expr) => {
         match core::str::from_utf8(&$buf) {
-            Ok(s) => log::$level!($fmt, s),
-            Err(_) => log::$level!($fmt, $buf),
-        }
+            Ok(_s) => atat_log!($level, $fmt, _s),
+            Err(_) => atat_log!($level, $fmt, $buf),
+        };
+    };
+}
+
+#[cfg(all(
+    feature = "log-logging",
+    not(any(
+        feature = "defmt-default",
+        feature = "defmt-trace",
+        feature = "defmt-debug",
+        feature = "defmt-info",
+        feature = "defmt-warn",
+        feature = "defmt-error"
+    ))
+))]
+#[macro_export]
+macro_rules! atat_log {
+    ($level:ident, $($arg:tt)+) => {
+        log::$level!($($arg)+);
+    }
+}
+#[cfg(all(
+    any(
+        feature = "defmt-default",
+        feature = "defmt-trace",
+        feature = "defmt-debug",
+        feature = "defmt-info",
+        feature = "defmt-warn",
+        feature = "defmt-error"
+    ),
+    not(feature = "log-logging")
+))]
+#[macro_export]
+macro_rules! atat_log {
+    ($level:ident, $($arg:tt)+) => {
+        defmt::$level!($($arg)+);
+    }
+}
+#[cfg(not(any(
+    any(
+        feature = "defmt-default",
+        feature = "defmt-trace",
+        feature = "defmt-debug",
+        feature = "defmt-info",
+        feature = "defmt-warn",
+        feature = "defmt-error"
+    ),
+    feature = "log-logging"
+)))]
+#[macro_export]
+macro_rules! atat_log {
+    ($level:ident, $($arg:tt)+) => {
+        ();
     };
 }
 

--- a/serde_at/Cargo.toml
+++ b/serde_at/Cargo.toml
@@ -13,7 +13,6 @@ version = "0.4.3-alpha.0"
 
 [dependencies]
 heapless = { version = "0.5.5", features = ["serde"] }
-log = "0.4.8"
 
 [dependencies.serde]
 default-features = false


### PR DESCRIPTION
This PR will add support for defmt (https://defmt.ferrous-systems.com/introduction.html) logging.

It introduces a couple of new feature flags, and changes the old logging flag:

 - `log-logging`: Disabled by default. Enable log statements on various log levels to aid debugging. Powered by `log`.
 - `defmt-default`: Disabled by default. Enable log statements at INFO, or TRACE, level and up, to aid debugging. Powered by `defmt`.
 - `defmt-trace`: Disabled by default. Enable log statements at TRACE level and up, to aid debugging. Powered by `defmt`.
 - `defmt-debug`: Disabled by default. Enable log statements at DEBUG level and up, to aid debugging. Powered by `defmt`.
 - `defmt-info`: Disabled by default. Enable log statements at INFO level and up, to aid debugging. Powered by `defmt`.
 - `defmt-warn`: Disabled by default. Enable log statements at WARN level and up, to aid debugging. Powered by `defmt`.
 - `defmt-error`: Disabled by default. Enable log statements at ERROR level and up, to aid debugging. Powered by `defmt`.

### Missing
~~Currently it breaks the `log_str!` helper macro, due to a missing step with string interning to be done.~~


Fixes #57 