### PR TITLE
Add "std" feature to fix compile when using std

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,29 @@ jobs:
           target: thumbv7m-none-eabi
           override: true
 
-      - name: Build
+      - name: Build (native)
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all --all-features --target thumbv7m-none-eabi
+          args: --all --all-features
+
+      - name: Build (ARM)
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          # every feature except std. Can't specify --features in the root so
+          # directly specify just the atat crate
+          args: --manifest-path=atat/Cargo.toml
+            --target thumbv7m-none-eabi
+            --features "
+              derive
+              log-logging
+              defmt-default
+              defmt-trace
+              defmt-debug
+              defmt-info
+              defmt-warn
+              defmt-error"
 
       - name: Test
         uses: actions-rs/cargo@v1

--- a/atat/Cargo.toml
+++ b/atat/Cargo.toml
@@ -43,6 +43,8 @@ derive = ["atat_derive"]
 
 log-logging = ["log"]
 
+std = ["serde_at/std"]
+
 defmt-default = []
 defmt-trace = []
 defmt-debug = []

--- a/serde_at/Cargo.toml
+++ b/serde_at/Cargo.toml
@@ -23,3 +23,4 @@ serde_derive = "^1"
 
 [features]
 custom-error-messages = []
+std = []

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -600,6 +600,9 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg(any(test, feature = "std"))]
+impl std::error::Error for Error {}
+
 /// Deserializes an instance of type `T` from bytes of AT Response text
 pub fn from_slice<'a, T>(v: &'a [u8]) -> Result<T>
 where

--- a/serde_at/src/lib.rs
+++ b/serde_at/src/lib.rs
@@ -4,7 +4,7 @@
 #![deny(warnings)]
 #![allow(clippy::multiple_crate_versions)]
 #![allow(clippy::missing_errors_doc)]
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 
 pub mod de;
 pub mod ser;

--- a/serde_at/src/ser/mod.rs
+++ b/serde_at/src/ser/mod.rs
@@ -111,6 +111,9 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg(any(test, feature = "std"))]
+impl std::error::Error for Error {}
+
 pub(crate) struct Serializer<'a, B, C>
 where
     B: heapless::ArrayLength<u8>,


### PR DESCRIPTION
I get 15 errors trying to compile `serde_at` when using std, because serde defines its internal type `StdError` as `std::error::Error`, which serde_at does not implement. Here's an example:
```
error[E0277]: the trait bound `ser::Error: serde::de::StdError` is not satisfied
   --> /home/mon/.cargo/registry/src/github.com-aaa/serde_at-0.4.3/src/ser/mod.rs:501:18
    |
501 |     type Error = Error;
    |                  ^^^^^ the trait `serde::de::StdError` is not implemented for `ser::Error`
```

By adding an optional `std` feature which implements this trait, compilation is successful!