### PR TITLE
Fix derive(AtatCmd) missing serde_at import

### DIFF
--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -229,6 +229,9 @@ pub use self::derive::AtatLen;
 #[cfg(feature = "derive")]
 pub use serde_at;
 
+#[cfg(feature = "derive")]
+pub use typenum;
+
 pub use self::client::Client;
 pub use self::error::Error;
 pub use self::ingress_manager::{

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -95,7 +95,7 @@
 //!
 //! ### Basic usage example (More available in examples folder):
 //! ```ignore
-//! 
+//!
 //! use cortex_m::asm;
 //! use hal::{
 //!     gpio::{
@@ -225,6 +225,9 @@ pub mod derive;
 
 #[cfg(feature = "derive")]
 pub use self::derive::AtatLen;
+
+#[cfg(feature = "derive")]
+pub use serde_at;
 
 pub use self::client::Client;
 pub use self::error::Error;

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -95,7 +95,7 @@
 //!
 //! ### Basic usage example (More available in examples folder):
 //! ```ignore
-//!
+//! 
 //! use cortex_m::asm;
 //! use hal::{
 //!     gpio::{

--- a/atat_derive/src/cmd.rs
+++ b/atat_derive/src/cmd.rs
@@ -96,7 +96,7 @@ pub fn atat_cmd(input: TokenStream) -> TokenStream {
             #[inline]
             fn as_bytes(&self) -> ::heapless::Vec<u8, Self::CommandLen> {
                 let s: ::heapless::String<::heapless::consts::#subcmd_len_ident> = ::heapless::String::from(#cmd);
-                match serde_at::to_vec(self, s, serde_at::SerializeOptions {
+                match atat::serde_at::to_vec(self, s, atat::serde_at::SerializeOptions {
                     value_sep: #value_sep,
                     cmd_prefix: #cmd_prefix,
                     termination: #termination
@@ -108,7 +108,7 @@ pub fn atat_cmd(input: TokenStream) -> TokenStream {
 
             #[inline]
             fn parse(&self, resp: &[u8]) -> core::result::Result<#resp, atat::Error> {
-                serde_at::from_slice::<#resp>(resp).map_err(|e| {
+                atat::serde_at::from_slice::<#resp>(resp).map_err(|e| {
                     atat::Error::ParseString
                 })
             }

--- a/atat_derive/src/len.rs
+++ b/atat_derive/src/len.rs
@@ -69,7 +69,7 @@ pub fn enum_len(
                 };
             }
             enum_len = quote! {
-                <#fields_len as ::typenum::type_operators::Max<#enum_len>>::Output
+                <#fields_len as atat::typenum::type_operators::Max<#enum_len>>::Output
             };
         }
     }


### PR DESCRIPTION
When deriving AtatCmd, I get an error because my app does not need `serde_at` directly:
```
19 | #[derive(Clone, AtatCmd)]
   |                 ^^^^^^^ use of undeclared type or module `serde_at`
   |
   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

I think this is caused by the `#[inline]` in the macro directly pasting the code. By re-exporting `serde_at` in `atat`, we can get around this.

I'm not well versed in idiomatic rust, so hopefully this is a good way to fix this!