### PR TITLE
Feature/Byte Vec Deserialize Wrapper

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -16,10 +16,10 @@ jobs:
       # Note: If you need to combine the coverage info of multiple
       # feature sets, you need a `.tarpaulin.toml` config file, see
       # the link above for those docs.
-      - uses: actions-rs/tarpaulin@v0.1
-        with:
-          run-types: Tests,Lib,Bins
-          args: --ignore-tests --all-features
+      - name: Install cargo-tarpaulin
+        run: "cargo install cargo-tarpaulin -f"
+      - name: Run cargo-tarpaulin
+        run: "cargo tarpaulin --out Xml --verbose --all-features --run-types Tests,Lib,Bins --ignore-tests"
       # Note: closed-source code needs to provide a token,
       # but open source code does not.
       - name: Upload to codecov.io

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -94,7 +94,7 @@
 //!
 //! ### Basic usage example (More available in examples folder):
 //! ```ignore
-//!
+//! 
 //! use cortex_m::asm;
 //! use hal::{
 //!     gpio::{

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -94,7 +94,7 @@
 //!
 //! ### Basic usage example (More available in examples folder):
 //! ```ignore
-//! 
+//!
 //! use cortex_m::asm;
 //! use hal::{
 //!     gpio::{

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -4,7 +4,7 @@ use core::str::FromStr;
 use core::{fmt, str};
 
 use serde::de::{self, Visitor};
-use serde::{Deserialize, export};
+use serde::{export, Deserialize};
 
 use self::enum_::VariantAccess;
 use self::map::MapAccess;
@@ -17,7 +17,6 @@ mod seq;
 /// Deserialization result
 pub type Result<T> = core::result::Result<T, Error>;
 
-
 /// Wrapper type to allow deserializing a number of chars as a char vector
 ///
 /// Example:
@@ -28,11 +27,11 @@ pub type Result<T> = core::result::Result<T, Error>;
 ///
 /// #[derive(Debug, Deserialize, PartialEq)]
 /// struct CharVecStruct(CharVec<consts::U7>)
-/// 
+///
 /// let vec: CharVecStruct = from_str("+CCID: IMP_MSG")
-/// 
+///
 /// let stru = CharVecTest(CharVec(heapless::Vec::from_slice(&['I', 'M', 'P', '_', 'M', 'S', 'G']).unwrap()));
-/// 
+///
 /// assert_eq!(vec, Ok(stru));
 /// ```
 #[derive(Debug, PartialEq)]
@@ -66,7 +65,10 @@ where
 
                 while let Some(value) = seq.next_element()? {
                     if values.push(value).is_err() {
-                        return Err(<A::Error as serde::de::Error>::invalid_length(values.capacity() + 1, &self))?;
+                        return Err(<A::Error as serde::de::Error>::invalid_length(
+                            values.capacity() + 1,
+                            &self,
+                        ))?;
                     }
                 }
 
@@ -692,9 +694,9 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::CharVec;
     use heapless::{consts, String, Vec};
     use serde_derive::Deserialize;
-    use super::CharVec;
 
     #[derive(Debug, Deserialize, PartialEq)]
     struct CFG {
@@ -806,10 +808,7 @@ mod tests {
 
     #[test]
     fn char_test() {
-        assert_eq!(
-            crate::from_str("+CCID: B"),
-            Ok(CharHandle('B'))
-        );
+        assert_eq!(crate::from_str("+CCID: B"), Ok(CharHandle('B')));
     }
 
     #[test]
@@ -818,10 +817,12 @@ mod tests {
     }
 
     #[test]
-    fn char_vec_struct(){
+    fn char_vec_struct() {
         #[derive(Debug, Deserialize, PartialEq)]
         struct CharVecTest(CharVec<consts::U4>);
-        let stru = CharVecTest(CharVec(heapless::Vec::from_slice(&['I', 'M', 'P', '_']).unwrap()));
+        let stru = CharVecTest(CharVec(
+            heapless::Vec::from_slice(&['I', 'M', 'P', '_']).unwrap(),
+        ));
         assert_eq!(crate::from_str("+CCID: IMP_"), Ok(stru));
     }
 }

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -43,7 +43,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 /// assert_eq!(incoming, Ok(expected));
 /// ```
 #[derive(Debug, PartialEq)]
-struct CharVec<T: heapless::ArrayLength<char>>(heapless::Vec<char, T>);
+pub struct CharVec<T: heapless::ArrayLength<char>>(heapless::Vec<char, T>);
 
 impl<'de, N> Deserialize<'de> for CharVec<N>
 where

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -32,7 +32,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 ///     value: i32,
 /// }
 ///
-/// let incomming: CommandStruct = from_str("+CCID: 4,IMP_MSG,-12")
+/// let incoming: CommandStruct = from_str("+CCID: 4,IMP_MSG,-12")
 ///
 /// let expected = CommandStruct{
 ///     id: 4,
@@ -40,7 +40,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 ///     value: -12,
 /// }
 ///
-/// assert_eq!(incomming, Ok(expected));
+/// assert_eq!(incoming, Ok(expected));
 /// ```
 #[derive(Debug, PartialEq)]
 struct CharVec<T: heapless::ArrayLength<char>>(heapless::Vec<char, T>);

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -45,6 +45,13 @@ pub type Result<T> = core::result::Result<T, Error>;
 #[derive(Debug, PartialEq)]
 pub struct CharVec<T: heapless::ArrayLength<char>>(heapless::Vec<char, T>);
 
+impl <T> CharVec<T>
+    where T: heapless::ArrayLength<char>{
+    pub fn new() -> Self{
+        CharVec(heapless::Vec::<char, T>::new())
+    }
+}
+
 impl<'de, N> Deserialize<'de> for CharVec<N>
 where
     N: heapless::ArrayLength<char>,
@@ -826,6 +833,8 @@ mod tests {
 
     #[test]
     fn char_vec_struct() {
+        let expectation: CharVec<consts::U4> = CharVec::new();
+        assert_eq!(CharVec(heapless::Vec::<char, consts::U4>::new()), expectation);
         let expectation: CharVec<consts::U4> =
             CharVec(heapless::Vec::from_slice(&['I', 'M', 'P', '_']).unwrap());
         assert_eq!(crate::from_str("+CCID: IMP_"), Ok(expectation));

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -45,13 +45,23 @@ pub type Result<T> = core::result::Result<T, Error>;
 #[derive(Debug, PartialEq)]
 pub struct CharVec<T: heapless::ArrayLength<char>>(heapless::Vec<char, T>);
 
-impl <T> CharVec<T>
-    where T: heapless::ArrayLength<char>{
-    pub fn new() -> Self{
-        CharVec(heapless::Vec::<char, T>::new())
+impl<T> CharVec<T>
+where
+    T: heapless::ArrayLength<char>,
+{
+    #[must_use]
+    pub fn new() -> Self {
+        Self(heapless::Vec::<char, T>::new())
     }
 }
-
+impl<T> Default for CharVec<T>
+where
+    T: heapless::ArrayLength<char>,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
 impl<'de, N> Deserialize<'de> for CharVec<N>
 where
     N: heapless::ArrayLength<char>,
@@ -834,7 +844,10 @@ mod tests {
     #[test]
     fn char_vec_struct() {
         let expectation: CharVec<consts::U4> = CharVec::new();
-        assert_eq!(CharVec(heapless::Vec::<char, consts::U4>::new()), expectation);
+        assert_eq!(
+            CharVec(heapless::Vec::<char, consts::U4>::new()),
+            expectation
+        );
         let expectation: CharVec<consts::U4> =
             CharVec(heapless::Vec::from_slice(&['I', 'M', 'P', '_']).unwrap());
         assert_eq!(crate::from_str("+CCID: IMP_"), Ok(expectation));

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -4,10 +4,11 @@ use core::str::FromStr;
 use core::{fmt, str};
 
 use serde::de::{self, Visitor};
+use serde::{Deserialize, export};
 
 use self::enum_::VariantAccess;
 use self::map::MapAccess;
-use self::seq::SeqAccess;
+use self::seq::{SeqAccess, SeqByteAccess};
 
 mod enum_;
 mod map;
@@ -15,6 +16,66 @@ mod seq;
 
 /// Deserialization result
 pub type Result<T> = core::result::Result<T, Error>;
+
+
+/// Wrapper type to allow deserializing a number of chars as a char vector
+///
+/// Example:
+/// ```
+/// use heapless::{consts, String};
+/// use serde_at::{to_string, Bytes, SerializeOptions};
+/// use serde_derive::Serialize;
+///
+/// #[derive(Debug, Deserialize, PartialEq)]
+/// struct CharVecStruct(CharVec<consts::U7>)
+/// 
+/// let vec: CharVecStruct = from_str("+CCID: IMP_MSG")
+/// 
+/// let stru = CharVecTest(CharVec(heapless::Vec::from_slice(&['I', 'M', 'P', '_', 'M', 'S', 'G']).unwrap()));
+/// 
+/// assert_eq!(vec, Ok(stru));
+/// ```
+#[derive(Debug, PartialEq)]
+struct CharVec<T: heapless::ArrayLength<char>>(heapless::Vec<char, T>);
+
+impl<'de, N> Deserialize<'de> for CharVec<N>
+where
+    N: heapless::ArrayLength<char>,
+{
+    fn deserialize<D>(deserializer: D) -> export::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct ValueVisitor<'de, N>(core::marker::PhantomData<(&'de (), char, N)>);
+
+        impl<'de, N> de::Visitor<'de> for ValueVisitor<'de, N>
+        where
+            N: heapless::ArrayLength<char>,
+        {
+            type Value = CharVec<N>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a sequence")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> export::Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut values = heapless::Vec::new();
+
+                while let Some(value) = seq.next_element()? {
+                    if values.push(value).is_err() {
+                        return Err(<A::Error as serde::de::Error>::invalid_length(values.capacity() + 1, &self))?;
+                    }
+                }
+
+                Ok(CharVec(values))
+            }
+        }
+        deserializer.deserialize_bytes(ValueVisitor(core::marker::PhantomData))
+    }
+}
 
 /// This type represents all possible errors that can occur when deserializing AT Command strings
 #[allow(clippy::pub_enum_variant_names)]
@@ -373,11 +434,13 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         deserialize_fromstr!(self, visitor, f64, visit_f64, b"0123456789+-.eE")
     }
 
-    fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        unreachable!()
+        let peek = self.parse_whitespace().ok_or(Error::EofWhileParsingValue)?;
+        self.eat_char();
+        visitor.visit_char(peek as char)
     }
 
     fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
@@ -410,11 +473,11 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     }
 
     /// Unsupported
-    fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        unreachable!()
+        Ok(visitor.visit_seq(SeqByteAccess::new(self))?)
     }
 
     /// Unsupported
@@ -631,6 +694,7 @@ where
 mod tests {
     use heapless::{consts, String, Vec};
     use serde_derive::Deserialize;
+    use super::CharVec;
 
     #[derive(Debug, Deserialize, PartialEq)]
     struct CFG {
@@ -653,6 +717,9 @@ mod tests {
 
     #[derive(Clone, Debug, PartialEq, Deserialize)]
     struct Handle(pub usize);
+
+    #[derive(Clone, Debug, PartialEq, Deserialize)]
+    struct CharHandle(pub char);
 
     #[test]
     fn simple_struct() {
@@ -738,7 +805,23 @@ mod tests {
     }
 
     #[test]
+    fn char_test() {
+        assert_eq!(
+            crate::from_str("+CCID: B"),
+            Ok(CharHandle('B'))
+        );
+    }
+
+    #[test]
     fn newtype_struct() {
         assert_eq!(crate::from_str("+CCID: 15"), Ok(Handle(15)));
+    }
+
+    #[test]
+    fn char_vec_struct(){
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct CharVecTest(CharVec<consts::U4>);
+        let stru = CharVecTest(CharVec(heapless::Vec::from_slice(&['I', 'M', 'P', '_']).unwrap()));
+        assert_eq!(crate::from_str("+CCID: IMP_"), Ok(stru));
     }
 }

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -68,7 +68,7 @@ where
                         return Err(<A::Error as serde::de::Error>::invalid_length(
                             values.capacity() + 1,
                             &self,
-                        ))?;
+                        ));
                     }
                 }
 

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -34,7 +34,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 ///
 /// let incomming: CommandStruct = from_str("+CCID: 4,IMP_MSG,-12")
 ///
-/// let expected = CommandStruct{ 
+/// let expected = CommandStruct{
 ///     id: 4,
 ///     vec : CharVec(heapless::Vec::from_slice(&['I', 'M', 'P', '_', 'M', 'S', 'G']).unwrap()),
 ///     value: -12,
@@ -826,9 +826,8 @@ mod tests {
 
     #[test]
     fn char_vec_struct() {
-        let expectation: CharVec<consts::U4> = CharVec(
-            heapless::Vec::from_slice(&['I', 'M', 'P', '_']).unwrap(),
-        );
+        let expectation: CharVec<consts::U4> =
+            CharVec(heapless::Vec::from_slice(&['I', 'M', 'P', '_']).unwrap());
         assert_eq!(crate::from_str("+CCID: IMP_"), Ok(expectation));
     }
 }

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -26,13 +26,21 @@ pub type Result<T> = core::result::Result<T, Error>;
 /// use serde_derive::Serialize;
 ///
 /// #[derive(Debug, Deserialize, PartialEq)]
-/// struct CharVecStruct(CharVec<consts::U7>)
+/// struct CommandStruct{
+///     id: u8,
+///     vec: CharVec<consts::U7>
+///     value: i32,
+/// }
 ///
-/// let vec: CharVecStruct = from_str("+CCID: IMP_MSG")
+/// let incomming: CommandStruct = from_str("+CCID: 4,IMP_MSG,-12")
 ///
-/// let stru = CharVecTest(CharVec(heapless::Vec::from_slice(&['I', 'M', 'P', '_', 'M', 'S', 'G']).unwrap()));
+/// let expected = CommandStruct{ 
+///     id: 4,
+///     vec : CharVec(heapless::Vec::from_slice(&['I', 'M', 'P', '_', 'M', 'S', 'G']).unwrap()),
+///     value: -12,
+/// }
 ///
-/// assert_eq!(vec, Ok(stru));
+/// assert_eq!(incomming, Ok(expected));
 /// ```
 #[derive(Debug, PartialEq)]
 struct CharVec<T: heapless::ArrayLength<char>>(heapless::Vec<char, T>);
@@ -818,11 +826,9 @@ mod tests {
 
     #[test]
     fn char_vec_struct() {
-        #[derive(Debug, Deserialize, PartialEq)]
-        struct CharVecTest(CharVec<consts::U4>);
-        let stru = CharVecTest(CharVec(
+        let expectation: CharVec<consts::U4> = CharVec(
             heapless::Vec::from_slice(&['I', 'M', 'P', '_']).unwrap(),
-        ));
-        assert_eq!(crate::from_str("+CCID: IMP_"), Ok(stru));
+        );
+        assert_eq!(crate::from_str("+CCID: IMP_"), Ok(expectation));
     }
 }

--- a/serde_at/src/de/seq.rs
+++ b/serde_at/src/de/seq.rs
@@ -42,7 +42,6 @@ impl<'a, 'de> de::SeqAccess<'de> for SeqAccess<'a, 'de> {
     }
 }
 
-#[allow(clippy::module_name_repetitions)]
 pub struct SeqByteAccess<'a, 'b> {
     de: &'a mut Deserializer<'b>,
 }

--- a/serde_at/src/de/seq.rs
+++ b/serde_at/src/de/seq.rs
@@ -42,6 +42,7 @@ impl<'a, 'de> de::SeqAccess<'de> for SeqAccess<'a, 'de> {
     }
 }
 
+#[allow(clippy::module_name_repetitions)]
 pub struct SeqByteAccess<'a, 'b> {
     de: &'a mut Deserializer<'b>,
 }

--- a/serde_at/src/de/seq.rs
+++ b/serde_at/src/de/seq.rs
@@ -41,3 +41,35 @@ impl<'a, 'de> de::SeqAccess<'de> for SeqAccess<'a, 'de> {
         Ok(Some(seed.deserialize(&mut *self.de)?))
     }
 }
+
+#[allow(clippy::module_name_repetitions)]
+pub struct SeqByteAccess<'a, 'b> {
+    de: &'a mut Deserializer<'b>,
+}
+
+impl<'a, 'b> SeqByteAccess<'a, 'b> {
+    pub(crate) fn new(de: &'a mut Deserializer<'b>) -> Self {
+        SeqByteAccess { de }
+    }
+}
+
+impl<'a, 'de> de::SeqAccess<'de> for SeqByteAccess<'a, 'de> {
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.de.parse_whitespace() {
+            Some(b',') => {
+                return Ok(None);
+            }
+            Some(_) => { }
+            None => {
+                return Ok(None);
+            }
+        };
+
+        Ok(Some(seed.deserialize(&mut *self.de)?))
+    }
+}

--- a/serde_at/src/de/seq.rs
+++ b/serde_at/src/de/seq.rs
@@ -64,7 +64,7 @@ impl<'a, 'de> de::SeqAccess<'de> for SeqByteAccess<'a, 'de> {
             Some(b',') => {
                 return Ok(None);
             }
-            Some(_) => { }
+            Some(_) => {}
             None => {
                 return Ok(None);
             }

--- a/serde_at/src/de/seq.rs
+++ b/serde_at/src/de/seq.rs
@@ -61,13 +61,10 @@ impl<'a, 'de> de::SeqAccess<'de> for SeqByteAccess<'a, 'de> {
         T: de::DeserializeSeed<'de>,
     {
         match self.de.parse_whitespace() {
-            Some(b',') => {
+            Some(b',') | None => {
                 return Ok(None);
             }
             Some(_) => {}
-            None => {
-                return Ok(None);
-            }
         };
 
         Ok(Some(seed.deserialize(&mut *self.de)?))

--- a/serde_at/src/lib.rs
+++ b/serde_at/src/lib.rs
@@ -12,7 +12,7 @@ pub mod ser;
 pub use serde;
 
 #[doc(inline)]
-pub use self::de::{from_slice, CharVec, from_str};
+pub use self::de::{from_slice, from_str, CharVec};
 #[doc(inline)]
 pub use self::ser::{to_string, to_vec, Bytes, SerializeOptions};
 

--- a/serde_at/src/lib.rs
+++ b/serde_at/src/lib.rs
@@ -12,7 +12,7 @@ pub mod ser;
 pub use serde;
 
 #[doc(inline)]
-pub use self::de::{from_slice, from_str};
+pub use self::de::{from_slice, CharVec, from_str};
 #[doc(inline)]
 pub use self::ser::{to_string, to_vec, Bytes, SerializeOptions};
 


### PR DESCRIPTION
Wrapper for deserializing a Vector of bytes like fx "+UUWLE:32AB6A7A4044".
Primarily done to parse bssid for [ublox-short-range-rs](https://github.com/BlackbirdHQ/ublox-short-range-rs/).
But this is kind of a catch all for any Non comma separated value in any AT command.