### PR TITLE
Implement support for multi-line responses

### DIFF
--- a/atat/src/derive.rs
+++ b/atat/src/derive.rs
@@ -232,10 +232,10 @@ mod tests {
             String::<consts::U50>::from("4,77,\"whaat\",88,1")
         );
 
-        assert_eq!(Ok(MixedEnum::UnitVariant), from_str::<MixedEnum<'_>>(":0"));
+        assert_eq!(Ok(MixedEnum::UnitVariant), from_str::<MixedEnum<'_>>("0"));
         assert_eq!(
             Ok(MixedEnum::SingleSimpleTuple(67)),
-            from_str::<MixedEnum<'_>>(":1,67")
+            from_str::<MixedEnum<'_>>("1,67")
         );
         assert_eq!(
             Ok(MixedEnum::AdvancedTuple(
@@ -244,12 +244,12 @@ mod tests {
                 -43,
                 SimpleEnumU32::C
             )),
-            from_str::<MixedEnum<'_>>(":2,251,\"deser\",-43,2")
+            from_str::<MixedEnum<'_>>("2,251,\"deser\",-43,2")
         );
 
         assert_eq!(
             Ok(MixedEnum::SingleSimpleTupleLifetime("abc")),
-            from_str::<MixedEnum<'_>>(":6,\"abc\"")
+            from_str::<MixedEnum<'_>>("6,\"abc\"")
         );
     }
 }

--- a/atat/src/ingress_manager.rs
+++ b/atat/src/ingress_manager.rs
@@ -5,8 +5,6 @@ use crate::error::Error;
 use crate::queues::{ComConsumer, ComItem, ResItem, ResProducer, UrcItem, UrcProducer};
 use crate::{Command, Config};
 
-use core::iter::FromIterator;
-
 type ByteVec<L> = Vec<u8, L>;
 
 trait SliceExt {
@@ -93,17 +91,16 @@ pub fn get_line<L: ArrayLength<u8>, I: ArrayLength<u8>>(
 
             let (left, right) = buf.split_at(index + needle.len() + white_space);
 
-            let return_buf = Vec::from_iter(
-                if trim_response {
-                    left.trim(&[b'\t', b' ', format_char, line_term_char])
-                } else {
-                    left
-                }
-                .iter()
-                .cloned(),
-            );
+            let return_buf = if trim_response {
+                left.trim(&[b'\t', b' ', format_char, line_term_char])
+            } else {
+                left
+            }
+            .iter()
+            .cloned()
+            .collect();
 
-            *buf = Vec::from_iter(right.iter().cloned());
+            *buf = right.iter().cloned().collect();
             Some(return_buf)
         }
         None => None,

--- a/atat/src/ingress_manager.rs
+++ b/atat/src/ingress_manager.rs
@@ -286,7 +286,7 @@ where
     /// interrupt, or a DMA interrupt, to move data from the peripheral into the
     /// ingress manager receive buffer.
     pub fn write(&mut self, data: &[u8]) {
-        atat_log!(trace, "Receiving {:?} bytes", data.len());
+        // atat_log!(debug, "Received response: \"{:?}\"", data);
 
         if self.buf.extend_from_slice(data).is_err() {
             self.notify_response(Err(Error::Overflow));
@@ -299,7 +299,7 @@ where
         match &resp {
             Ok(_r) => {
                 if _r.is_empty() {
-                    atat_log!(debug, "Received OK",)
+                    atat_log!(debug, "Received OK")
                 } else {
                     #[allow(clippy::single_match)]
                     match core::str::from_utf8(_r) {

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -94,7 +94,7 @@
 //!
 //! ### Basic usage example (More available in examples folder):
 //! ```ignore
-//!
+//! 
 //! use cortex_m::asm;
 //! use hal::{
 //!     gpio::{

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -94,7 +94,7 @@
 //!
 //! ### Basic usage example (More available in examples folder):
 //! ```ignore
-//! 
+//!
 //! use cortex_m::asm;
 //! use hal::{
 //!     gpio::{

--- a/atat/src/traits.rs
+++ b/atat/src/traits.rs
@@ -169,8 +169,6 @@ pub trait AtatClient {
     fn get_mode(&self) -> Mode;
 }
 
-
-
 impl<T, L> AtatResp for heapless::Vec<T, L>
 where
     T: AtatResp,
@@ -183,7 +181,7 @@ mod test {
     use super::*;
     use crate as atat;
     use atat_derive::{AtatEnum, AtatResp};
-    use heapless::{String, consts};
+    use heapless::{consts, String};
 
     #[derive(Debug, Clone, PartialEq, AtatEnum)]
     pub enum PDPContextStatus {
@@ -223,8 +221,8 @@ mod test {
         pub p_cscf_discovery: Option<u8>,
         #[at_arg(position = 9)]
         pub im_cn_signalling_flag_ind: Option<u8>,
-        // #[at_arg(position = 10)]
-        // pub nslpi: Option<u8>,
+        /* #[at_arg(position = 10)]
+         * pub nslpi: Option<u8>, */
     }
 
     #[test]

--- a/atat/src/traits.rs
+++ b/atat/src/traits.rs
@@ -168,3 +168,155 @@ pub trait AtatClient {
     /// - `Timeout`
     fn get_mode(&self) -> Mode;
 }
+
+
+
+impl<T, L> AtatResp for heapless::Vec<T, L>
+where
+    T: AtatResp,
+    L: ArrayLength<T>,
+{
+}
+
+#[cfg(all(test, feature = "derive"))]
+mod test {
+    use super::*;
+    use crate as atat;
+    use atat_derive::{AtatEnum, AtatResp};
+    use heapless::{String, consts};
+
+    #[derive(Debug, Clone, PartialEq, AtatEnum)]
+    pub enum PDPContextStatus {
+        /// 0: deactivated
+        Deactivated = 0,
+        /// 1: activated
+        Activated = 1,
+    }
+
+    #[derive(Debug, Clone, AtatResp, PartialEq)]
+    pub struct PDPContextState {
+        #[at_arg(position = 0)]
+        pub cid: u8,
+        #[at_arg(position = 1)]
+        pub status: PDPContextStatus,
+    }
+
+    #[derive(Debug, Clone, AtatResp, PartialEq)]
+    pub struct PDPContextDefinition {
+        #[at_arg(position = 0)]
+        pub cid: u8,
+        #[at_arg(position = 1)]
+        pub pdp_type: String<consts::U6>,
+        #[at_arg(position = 2)]
+        pub apn: String<consts::U99>,
+        #[at_arg(position = 3)]
+        pub pdp_addr: String<consts::U99>,
+        #[at_arg(position = 4)]
+        pub d_comp: u8,
+        #[at_arg(position = 5)]
+        pub h_comp: u8,
+        #[at_arg(position = 6)]
+        pub ipv4_addr_alloc: Option<u8>,
+        #[at_arg(position = 7)]
+        pub emergency_indication: Option<u8>,
+        #[at_arg(position = 8)]
+        pub p_cscf_discovery: Option<u8>,
+        #[at_arg(position = 9)]
+        pub im_cn_signalling_flag_ind: Option<u8>,
+        // #[at_arg(position = 10)]
+        // pub nslpi: Option<u8>,
+    }
+
+    #[test]
+    fn single_multi_response() {
+        let mut v = Vec::<_, heapless::consts::U5>::from_slice(&[PDPContextState {
+            cid: 1,
+            status: PDPContextStatus::Deactivated,
+        }])
+        .unwrap();
+
+        let mut resp: heapless::Vec<PDPContextState, heapless::consts::U5> =
+            serde_at::from_slice(b"+CGACT: 1,0\r\n").unwrap();
+
+        assert_eq!(resp.pop(), v.pop());
+        assert_eq!(resp.pop(), None);
+    }
+
+    #[test]
+    fn multi_response() {
+        let mut v = Vec::<_, heapless::consts::U3>::from_slice(&[
+            PDPContextState {
+                cid: 1,
+                status: PDPContextStatus::Deactivated,
+            },
+            PDPContextState {
+                cid: 2,
+                status: PDPContextStatus::Activated,
+            },
+            PDPContextState {
+                cid: 3,
+                status: PDPContextStatus::Deactivated,
+            },
+        ])
+        .unwrap();
+
+        let mut resp: heapless::Vec<PDPContextState, heapless::consts::U3> =
+            serde_at::from_slice(b"+CGACT: 1,0\r\n+CGACT: 2,1\r\n+CGACT: 3,0").unwrap();
+
+        assert_eq!(resp.pop(), v.pop());
+        assert_eq!(resp.pop(), v.pop());
+        assert_eq!(resp.pop(), v.pop());
+        assert_eq!(resp.pop(), None);
+    }
+
+    #[test]
+    fn multi_response_advanced() {
+        let mut v = Vec::<_, heapless::consts::U3>::from_slice(&[
+            PDPContextDefinition {
+                cid: 2,
+                pdp_type: String::from("IP"),
+                apn: String::from("em"),
+                pdp_addr: String::from("100.92.188.66"),
+                d_comp: 0,
+                h_comp: 0,
+                ipv4_addr_alloc: Some(0),
+                emergency_indication: Some(0),
+                p_cscf_discovery: Some(0),
+                im_cn_signalling_flag_ind: Some(0),
+            },
+            PDPContextDefinition {
+                cid: 1,
+                pdp_type: String::from("IP"),
+                apn: String::from("STATREAL"),
+                pdp_addr: String::from("0.0.0.0"),
+                d_comp: 0,
+                h_comp: 0,
+                ipv4_addr_alloc: None,
+                emergency_indication: None,
+                p_cscf_discovery: None,
+                im_cn_signalling_flag_ind: None,
+            },
+            PDPContextDefinition {
+                cid: 3,
+                pdp_type: String::from("IP"),
+                apn: String::from("tim.ibox.it"),
+                pdp_addr: String::from("0.0.0.0"),
+                d_comp: 0,
+                h_comp: 0,
+                ipv4_addr_alloc: None,
+                emergency_indication: None,
+                p_cscf_discovery: None,
+                im_cn_signalling_flag_ind: None,
+            },
+        ])
+        .unwrap();
+
+        let mut resp: heapless::Vec<PDPContextDefinition, heapless::consts::U3> =
+            serde_at::from_slice(b"+CGDCONT: 2,\"IP\",\"em\",\"100.92.188.66\",0,0,0,0,0,0\r\n+CGDCONT: 1,\"IP\",\"STATREAL\",\"0.0.0.0\",0,0\r\n+CGDCONT: 3,\"IP\",\"tim.ibox.it\",\"0.0.0.0\",0,0").unwrap();
+
+        assert_eq!(resp.pop(), v.pop());
+        assert_eq!(resp.pop(), v.pop());
+        assert_eq!(resp.pop(), v.pop());
+        assert_eq!(resp.pop(), None);
+    }
+}

--- a/atat_derive/src/urc.rs
+++ b/atat_derive/src/urc.rs
@@ -40,7 +40,7 @@ pub fn atat_urc(input: TokenStream) -> TokenStream {
                     panic!("cannot handle variants with more than one field")
                 }
                 quote! {
-                    #code => #ident::#variant_ident(atat::serde_at::from_slice::<#first_field>(&resp[index..]).map_err(|e| {
+                    #code => #ident::#variant_ident(atat::serde_at::from_slice::<#first_field>(&resp).map_err(|e| {
                         atat::Error::ParseString
                     })?),
                 }

--- a/serde_at/src/de/map.rs
+++ b/serde_at/src/de/map.rs
@@ -32,6 +32,7 @@ impl<'a, 'de> de::MapAccess<'de> for MapAccess<'a, 'de> {
             }
             _ => {}
         }
+
         seed.deserialize(&mut *self.de).map(Some)
     }
 

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -231,10 +231,8 @@ impl<'a> Deserializer<'a> {
                 match self.peek() {
                     Some(b':') => {
                         self.eat_char();
-                        self
-                        .parse_whitespace()
-                        .ok_or(Error::EofWhileParsingValue)?;
-                        return Ok(Some(()))
+                        self.parse_whitespace().ok_or(Error::EofWhileParsingValue)?;
+                        return Ok(Some(()));
                     }
                     Some(_) => {
                         self.eat_char();
@@ -243,7 +241,7 @@ impl<'a> Deserializer<'a> {
                         // Doesn't seem to be an AT command identifier. Reset index and continue
                         self.index = index;
                         break;
-                    },
+                    }
                 }
             }
         }
@@ -548,7 +546,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     {
         match self.parse_whitespace() {
             Some(b'+') | None => visitor.visit_none(),
-            Some(_) => visitor.visit_some(self)
+            Some(_) => visitor.visit_some(self),
         }
     }
 

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -223,6 +223,33 @@ impl<'a> Deserializer<'a> {
         }
     }
 
+    fn parse_at(&mut self) -> Result<Option<()>> {
+        // If we find a '+', check if it is an AT command identifier, ending in ':'
+        if let Some(b'+') = self.parse_whitespace() {
+            let index = self.index;
+            loop {
+                match self.peek() {
+                    Some(b':') => {
+                        self.eat_char();
+                        self
+                        .parse_whitespace()
+                        .ok_or(Error::EofWhileParsingValue)?;
+                        return Ok(Some(()))
+                    }
+                    Some(_) => {
+                        self.eat_char();
+                    }
+                    None => {
+                        // Doesn't seem to be an AT command identifier. Reset index and continue
+                        self.index = index;
+                        break;
+                    },
+                }
+            }
+        }
+        Ok(None)
+    }
+
     /// Consumes all the whitespace characters and returns a peek into the next character
     fn parse_whitespace(&mut self) -> Option<u8> {
         loop {
@@ -499,12 +526,12 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         unreachable!()
     }
 
-    /// Unsupported
     fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        Ok(visitor.visit_seq(SeqByteAccess::new(self))?)
+        self.parse_at()?;
+        visitor.visit_seq(SeqByteAccess::new(self))
     }
 
     /// Unsupported
@@ -520,8 +547,8 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         V: Visitor<'de>,
     {
         match self.parse_whitespace() {
-            Some(_) => visitor.visit_some(self),
-            None => visitor.visit_none(),
+            Some(b'+') | None => visitor.visit_none(),
+            Some(_) => visitor.visit_some(self)
         }
     }
 
@@ -545,6 +572,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
+        self.parse_at()?;
         visitor.visit_newtype_struct(self)
     }
 
@@ -552,9 +580,10 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        Ok(visitor.visit_seq(SeqAccess::new(self))?)
+        visitor.visit_seq(SeqAccess::new(self))
     }
 
+    /// Unsupported
     fn deserialize_tuple<V>(self, _len: usize, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
@@ -562,6 +591,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         unreachable!()
     }
 
+    /// Unsupported
     fn deserialize_tuple_struct<V>(
         self,
         _name: &'static str,
@@ -579,10 +609,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         V: Visitor<'de>,
     {
         self.parse_whitespace().ok_or(Error::EofWhileParsingValue)?;
-
-        let ret = visitor.visit_map(MapAccess::new(self))?;
-
-        Ok(ret)
+        visitor.visit_map(MapAccess::new(self))
     }
 
     fn deserialize_struct<V>(
@@ -594,6 +621,16 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
+        self.parse_at()?;
+
+        // Misuse EofWhileParsingObject here to indicate finished object in vec
+        // cases. Don't start a new sequence if this is not the first, and we
+        // have passed the last character in the buffer
+        //
+        // TODO: is there a better way of doing this?!
+        if self.index == self.slice.len() && self.index > 0 {
+            return Err(Error::EofWhileParsingObject);
+        }
         self.deserialize_seq(visitor)
     }
 
@@ -698,15 +735,10 @@ pub fn from_slice<'a, T>(v: &'a [u8]) -> Result<T>
 where
     T: de::Deserialize<'a>,
 {
-    if let Some(sp) = v.splitn(2, |&c| c == b':').last() {
-        let mut de = Deserializer::new(sp);
-        let value = de::Deserialize::deserialize(&mut de)?;
-        de.end()?;
-
-        Ok(value)
-    } else {
-        Err(Error::CustomError)
-    }
+    let mut de = Deserializer::new(v);
+    let value = de::Deserialize::deserialize(&mut de)?;
+    de.end()?;
+    Ok(value)
 }
 
 /// Deserializes an instance of type T from a string of AT Response text
@@ -720,10 +752,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::CharVec;
-    use heapless::{consts, String, Vec};
+    use heapless::{consts, String};
     use serde_derive::Deserialize;
 
-    #[derive(Debug, Deserialize, PartialEq)]
+    #[derive(Debug, Clone, Deserialize, PartialEq)]
     struct CFG {
         p1: u8,
         p2: i16,
@@ -800,24 +832,6 @@ mod tests {
             Ok(StringTest {
                 string: String::from("89883030000005421166")
             })
-        );
-    }
-
-    #[test]
-    // Not sure if this is the way it should actually be implemented?!
-    #[ignore]
-    fn simple_vec() {
-        #[derive(Debug, Deserialize, PartialEq)]
-        struct VecTest {
-            vec: Vec<u8, consts::U32>,
-        }
-
-        let vec =
-            Vec::from_slice(&[8, 9, 8, 8, 3, 0, 3, 0, 0, 0, 0, 0, 0, 5, 4, 2, 1, 1, 6, 6]).unwrap();
-
-        assert_eq!(
-            crate::from_slice("+CCID: \"89883030000005421166\"".as_bytes()),
-            Ok(VecTest { vec })
         );
     }
 

--- a/serde_at/src/de/seq.rs
+++ b/serde_at/src/de/seq.rs
@@ -46,7 +46,7 @@ impl<'a, 'de> de::SeqAccess<'de> for SeqAccess<'a, 'de> {
             // See matching TODO in `de::mod`..
             Err(Error::EofWhileParsingObject) => Ok(None),
             Err(e) => Err(e),
-            Ok(v) => Ok(Some(v))
+            Ok(v) => Ok(Some(v)),
         }
     }
 }

--- a/serde_at/src/ser/mod.rs
+++ b/serde_at/src/ser/mod.rs
@@ -410,10 +410,10 @@ where
 }
 
 /// Serializes the given data structure as a string
-pub fn to_string<'a, B, C, T>(
+pub fn to_string<B, C, T>(
     value: &T,
     cmd: String<C>,
-    options: SerializeOptions<'a>,
+    options: SerializeOptions<'_>,
 ) -> Result<String<B>>
 where
     B: heapless::ArrayLength<u8>,
@@ -426,10 +426,10 @@ where
 }
 
 /// Serializes the given data structure as a byte vector
-pub fn to_vec<'a, B, C, T>(
+pub fn to_vec<B, C, T>(
     value: &T,
     cmd: String<C>,
-    options: SerializeOptions<'a>,
+    options: SerializeOptions<'_>,
 ) -> Result<Vec<u8, B>>
 where
     B: heapless::ArrayLength<u8>,


### PR DESCRIPTION
This will correctly handle multi-line response AT commands using `heapless::Vec`

Eg.
```
> AT+CGACT?
< +CGACT: <cid>,<status>
< +CGACT: <cid>,<status>
...
< OK
```

Where `+CGACT: <cid>,<status>` can be repeated zero or more times, with a new cid,status pair.

fixes #63