### PR TITLE
Feature/error types

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -5,6 +5,14 @@ on:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
 jobs:
+  cancel_previous_runs:
+    name: Cancel previous runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+          
   security_audit:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -7,6 +7,14 @@ on:
   pull_request:
 
 jobs:
+  cancel_previous_runs:
+    name: Cancel previous runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+          
   grcov:
     name: Coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,14 @@ on:
       - master
 
 jobs:
+  cancel_previous_runs:
+    name: Cancel previous runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+          
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,14 @@ env:
   CLIPPY_PARAMS: -W clippy::all -W clippy::pedantic -W clippy::nursery -W clippy::cargo
 
 jobs:
+  cancel_previous_runs:
+    name: Cancel previous runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+          
   rustfmt:
     name: rustfmt
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,14 @@ on:
   pull_request:
 
 jobs:
+  cancel_previous_runs:
+    name: Cancel previous runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+          
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The following dependent crates provide platform-agnostic device drivers built on
 | Device Name | Description | Crate + Docs |
 |-------------|-------------|--------------|
 | [ublox-short-range-rs] | Driver crate for U-Blox host-based short range devices (wifi and BT) with AT-command interface | <!--[![crates.io][ublox-short-range-rs-crate-img]][ublox-short-range-rs] [![docs.rs][ublox-short-range-rs-docs-img]][ublox-short-range-rs-docs] --> |
-| [ublox-cellular-rs] | Driver crate for U-Blox host-based cellular devices with AT-command interface | <!--[![crates.io][ublox-cellular-rs-crate-img]][ublox-cellular-rs] [![docs.rs][ublox-cellular-rs-docs-img]][ublox-cellular-rs-docs] --> |
+| [ublox-cellular-rs] | Driver crate for U-Blox host-based cellular devices with AT-command interface | [![crates.io][ublox-cellular-rs-crate-img]][ublox-cellular-rs-crates] [![docs.rs][ublox-cellular-rs-docs-img]][ublox-cellular-rs-docs] |
 | [espresso] | AT based driver crate for ESP8266 WiFi modules | <!--[![crates.io][espresso-crate-img]][espresso] [![docs.rs][espresso-docs-img]][espresso-docs] --> |
 
 [ublox-short-range-rs]: https://github.com/BlackbirdHQ/ublox-short-range-rs
@@ -83,9 +83,10 @@ The following dependent crates provide platform-agnostic device drivers built on
 [ublox-short-range-rs-docs]: https://docs.rs/ublox-short-range-rs/ -->
 
 [ublox-cellular-rs]: https://github.com/BlackbirdHQ/ublox-cellular-rs
-<!-- [ublox-cellular-rs-crate-img]: https://img.shields.io/crates/v/ublox-cellular-rs.svg
+[ublox-cellular-rs-crate-img]: https://img.shields.io/crates/v/ublox-cellular-rs.svg
+[ublox-cellular-rs-crates]: https://crates.io/crates/ublox-cellular-rs
 [ublox-cellular-rs-docs-img]: https://docs.rs/ublox-cellular-rs/badge.svg
-[ublox-cellular-rs-docs]: https://docs.rs/ublox-cellular-rs/ -->
+[ublox-cellular-rs-docs]: https://docs.rs/ublox-cellular-rs/
 
 [espresso]: https://github.com/dbrgn/espresso
 <!-- [espresso-crate-img]: https://img.shields.io/crates/v/espresso.svg

--- a/atat/Cargo.toml
+++ b/atat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atat"
-version = "0.7.1"
+version = "0.7.2-alpha.0"
 authors = ["Mathias Koch <mk@blackbird.online>"]
 description = "AT Parser for serial based device crates"
 readme = "../README.md"

--- a/atat/examples/cortex-m-rt.rs
+++ b/atat/examples/cortex-m-rt.rs
@@ -30,8 +30,7 @@ use heapless::{consts, spsc::Queue};
 
 use crate::rt::entry;
 
-static mut INGRESS: Option<atat::IngressManager<DefaultDigester, DefaultUrcMatcher, consts::U256>> =
-    None;
+static mut INGRESS: Option<atat::IngressManager<consts::U256>> = None;
 static mut RX: Option<Rx<USART2>> = None;
 
 #[entry]
@@ -74,9 +73,9 @@ fn main() -> ! {
 
     serial.listen(Rxne);
 
-    static mut RES_QUEUE: ResQueue<consts::U256, consts::U1> = Queue(heapless::i::Queue::u8());
+    static mut RES_QUEUE: ResQueue<consts::U256> = Queue(heapless::i::Queue::u8());
     static mut URC_QUEUE: UrcQueue<consts::U256, consts::U10> = Queue(heapless::i::Queue::u8());
-    static mut COM_QUEUE: ComQueue<consts::U3> = Queue(heapless::i::Queue::u8());
+    static mut COM_QUEUE: ComQueue = Queue(heapless::i::Queue::u8());
 
     let queues = Queues {
         res_queue: unsafe { RES_QUEUE.split() },

--- a/atat/examples/rtic.rs
+++ b/atat/examples/rtic.rs
@@ -28,15 +28,15 @@ use heapless::{consts, spsc::Queue};
 #[app(device = hal::pac, peripherals = true)]
 const APP: () = {
     struct Resources {
-        ingress: atat::IngressManager<DefaultDigester, DefaultUrcMatcher, consts::U256>,
+        ingress: atat::IngressManager<consts::U256>,
         rx: Rx<USART2>,
     }
 
     #[init(spawn = [at_loop])]
     fn init(ctx: init::Context) -> init::LateResources {
-        static mut RES_QUEUE: ResQueue<consts::U256, consts::U1> = Queue(heapless::i::Queue::u8());
+        static mut RES_QUEUE: ResQueue<consts::U256> = Queue(heapless::i::Queue::u8());
         static mut URC_QUEUE: UrcQueue<consts::U256, consts::U10> = Queue(heapless::i::Queue::u8());
-        static mut COM_QUEUE: ComQueue<consts::U3> = Queue(heapless::i::Queue::u8());
+        static mut COM_QUEUE: ComQueue = Queue(heapless::i::Queue::u8());
 
         let p = Peripherals::take().unwrap();
 

--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -151,7 +151,7 @@ where
         if let Some(result) = self.res_c.dequeue() {
             return cmd
                 .parse(result.as_deref())
-                .map_err(|e| nb::Error::Other(e.into()))
+                .map_err(nb::Error::from)
                 .and_then(|r| {
                     if let ClientState::AwaitingResponse = self.state {
                         self.timer.try_start(self.config.cmd_cooldown).ok();
@@ -161,10 +161,10 @@ where
                         Err(nb::Error::WouldBlock)
                     }
                 })
-                .or_else(|e| {
+                .map_err(|e| {
                     self.timer.try_start(self.config.cmd_cooldown).ok();
                     self.state = ClientState::Idle;
-                    Err(e)
+                    e
                 });
         } else if let Mode::Timeout = self.config.mode {
             if self.timer.try_wait().is_ok() {

--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -121,7 +121,7 @@ where
 
         if !cmd.expects_response_code() {
             self.state = ClientState::Idle;
-            return cmd.parse(&[]).map_err(nb::Error::Other);
+            return cmd.parse(Ok(&[])).map_err(nb::Error::Other);
         }
 
         match self.config.mode {
@@ -160,6 +160,7 @@ where
                         Ok(r)
                     } else {
                         // FIXME: Is this correct?
+                        defmt::error!("Is this correct?! WouldBlock");
                         Err(nb::Error::WouldBlock)
                     }
                 })

--- a/atat/src/digest.rs
+++ b/atat/src/digest.rs
@@ -242,9 +242,6 @@ impl Digester for DefaultDigester {
                 };
 
                 defmt::trace!("Switching to state Idle");
-                if let Err(e) = &resp {
-                    defmt::error!("Error: {:?}", defmt::Debug2Format(e));
-                }
                 self.state = State::Idle;
                 return DigestResult::Response(resp);
             }

--- a/atat/src/error.rs
+++ b/atat/src/error.rs
@@ -51,14 +51,14 @@ where
 {
     fn from(ie: &InternalError) -> Self {
         match ie {
-            &InternalError::Read => Self::Read,
-            &InternalError::Write => Self::Write,
-            &InternalError::Timeout => Self::Timeout,
-            &InternalError::InvalidResponse => Self::InvalidResponse,
-            &InternalError::Aborted => Self::Aborted,
-            &InternalError::Overflow => Self::Overflow,
-            &InternalError::Parse => Self::Parse,
-            &InternalError::Error(ref e) => {
+            InternalError::Read => Self::Read,
+            InternalError::Write => Self::Write,
+            InternalError::Timeout => Self::Timeout,
+            InternalError::InvalidResponse => Self::InvalidResponse,
+            InternalError::Aborted => Self::Aborted,
+            InternalError::Overflow => Self::Overflow,
+            InternalError::Parse => Self::Parse,
+            InternalError::Error(ref e) => {
                 if let Ok(s) = String::from_utf8(e.clone()) {
                     if let Ok(e) = core::str::FromStr::from_str(s.as_str()) {
                         return Self::Error(e);

--- a/atat/src/error.rs
+++ b/atat/src/error.rs
@@ -1,6 +1,8 @@
+use heapless::{consts, String, Vec};
+
 /// Errors returned by, or used within the crate
-#[derive(Clone, Debug, PartialEq, defmt::Format)]
-pub enum Error {
+#[derive(Clone, Debug, PartialEq)]
+pub enum IngressError {
     /// Serial read error
     Read,
     /// Serial write error
@@ -14,5 +16,64 @@ pub enum Error {
     /// Buffer overflow
     Overflow,
     /// Failed to parse received response
-    ParseString,
+    Parse,
+    /// Error response containing any error message
+    Error(Vec<u8, consts::U64>),
+}
+
+/// Errors returned by, or used within the crate
+#[derive(Clone, Debug, PartialEq)]
+pub enum Error<E> {
+    /// Serial read error
+    Read,
+    /// Serial write error
+    Write,
+    /// Timed out while waiting for a response
+    Timeout,
+    /// Invalid response from module
+    InvalidResponse,
+    /// Command was aborted
+    Aborted,
+    /// Buffer overflow
+    Overflow,
+    /// Failed to parse received response
+    Parse,
+    /// Error response containing any error message
+    Error(E),
+}
+
+impl<E> From<&IngressError> for Error<E>
+where
+    E: core::str::FromStr,
+{
+    fn from(ie: &IngressError) -> Self {
+        match ie {
+            &IngressError::Read => Self::Read,
+            &IngressError::Write => Self::Write,
+            &IngressError::Timeout => Self::Timeout,
+            &IngressError::InvalidResponse => Self::InvalidResponse,
+            &IngressError::Aborted => Self::Aborted,
+            &IngressError::Overflow => Self::Overflow,
+            &IngressError::Parse => Self::Parse,
+            &IngressError::Error(ref e) => {
+                if let Ok(s) = String::from_utf8(e.clone()) {
+                    if let Ok(e) = core::str::FromStr::from_str(s.as_str()) {
+                        return Self::Error(e);
+                    }
+                }
+                Self::Parse
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, defmt::Format)]
+pub struct GenericError;
+
+impl core::str::FromStr for GenericError {
+    type Err = core::convert::Infallible;
+
+    fn from_str(_s: &str) -> Result<Self, Self::Err> {
+        Ok(GenericError)
+    }
 }

--- a/atat/src/error.rs
+++ b/atat/src/error.rs
@@ -21,6 +21,21 @@ pub enum InternalError {
     Error(Vec<u8, consts::U85>),
 }
 
+impl defmt::Format for InternalError {
+    fn format(&self, f: defmt::Formatter) {
+        match self {
+            InternalError::Read => defmt::write!(f, "Read"),
+            InternalError::Write => defmt::write!(f, "Write"),
+            InternalError::Timeout => defmt::write!(f, "Timeout"),
+            InternalError::InvalidResponse => defmt::write!(f, "InvalidResponse"),
+            InternalError::Aborted => defmt::write!(f, "Aborted"),
+            InternalError::Overflow => defmt::write!(f, "Overflow"),
+            InternalError::Parse => defmt::write!(f, "Parse"),
+            InternalError::Error(e) => defmt::write!(f, "Error({=[u8]:a})", &e),
+        }
+    }
+}
+
 /// Errors returned by the crate
 #[derive(Clone, Debug, PartialEq, defmt::Format)]
 pub enum Error<E = GenericError>

--- a/atat/src/error.rs
+++ b/atat/src/error.rs
@@ -2,7 +2,7 @@ use heapless::{consts, String, Vec};
 
 /// Errors returned by, or used within the crate
 #[derive(Clone, Debug, PartialEq)]
-pub enum IngressError {
+pub enum InternalError {
     /// Serial read error
     Read,
     /// Serial write error
@@ -18,12 +18,15 @@ pub enum IngressError {
     /// Failed to parse received response
     Parse,
     /// Error response containing any error message
-    Error(Vec<u8, consts::U64>),
+    Error(Vec<u8, consts::U85>),
 }
 
 /// Errors returned by, or used within the crate
-#[derive(Clone, Debug, PartialEq)]
-pub enum Error<E> {
+#[derive(Clone, Debug, PartialEq, defmt::Format)]
+pub enum Error<E = GenericError>
+where
+    E: defmt::Format
+{
     /// Serial read error
     Read,
     /// Serial write error
@@ -42,20 +45,20 @@ pub enum Error<E> {
     Error(E),
 }
 
-impl<E> From<&IngressError> for Error<E>
+impl<E> From<&InternalError> for Error<E>
 where
-    E: core::str::FromStr,
+    E: core::str::FromStr + defmt::Format,
 {
-    fn from(ie: &IngressError) -> Self {
+    fn from(ie: &InternalError) -> Self {
         match ie {
-            &IngressError::Read => Self::Read,
-            &IngressError::Write => Self::Write,
-            &IngressError::Timeout => Self::Timeout,
-            &IngressError::InvalidResponse => Self::InvalidResponse,
-            &IngressError::Aborted => Self::Aborted,
-            &IngressError::Overflow => Self::Overflow,
-            &IngressError::Parse => Self::Parse,
-            &IngressError::Error(ref e) => {
+            &InternalError::Read => Self::Read,
+            &InternalError::Write => Self::Write,
+            &InternalError::Timeout => Self::Timeout,
+            &InternalError::InvalidResponse => Self::InvalidResponse,
+            &InternalError::Aborted => Self::Aborted,
+            &InternalError::Overflow => Self::Overflow,
+            &InternalError::Parse => Self::Parse,
+            &InternalError::Error(ref e) => {
                 if let Ok(s) = String::from_utf8(e.clone()) {
                     if let Ok(e) = core::str::FromStr::from_str(s.as_str()) {
                         return Self::Error(e);

--- a/atat/src/helpers.rs
+++ b/atat/src/helpers.rs
@@ -67,29 +67,33 @@ pub fn get_line<L: ArrayLength<u8>, I: ArrayLength<u8>>(
         return None;
     }
 
+    
     let ind = if reverse {
         buf.windows(needle.len())
-            .rposition(|window| window == needle)
+        .rposition(|window| window == needle)
     } else {
         buf.windows(needle.len())
-            .position(|window| window == needle)
+        .position(|window| window == needle)
     };
+    
+    #[cfg(test)]
+    println!("{:?}", ind);
 
     match ind {
         Some(index) => {
             let white_space = buf
-                .iter()
-                .skip(index + needle.len())
-                .skip_while(|c| ![format_char, line_term_char].contains(c))
-                .position(|c| ![format_char, line_term_char].contains(c))
-                .unwrap_or(buf.len() - index - needle.len());
-
+            .iter()
+            .skip(index + needle.len())
+            .skip_while(|c| ![format_char, line_term_char, b'>', b'@'].contains(c))
+            .position(|c| ![format_char, line_term_char].contains(c))
+            .unwrap_or(buf.len() - index - needle.len());
+            
             let (left, right) = match buf.split_at(index + needle.len() + white_space) {
                 (left, right) if !swap => (left, right),
                 (left, right) if swap => (right, left),
                 _ => return None,
             };
-
+            
             let return_buf = if trim_response {
                 left.trim(&[b'\t', b' ', format_char, line_term_char])
             } else {
@@ -100,6 +104,8 @@ pub fn get_line<L: ArrayLength<u8>, I: ArrayLength<u8>>(
             .take(L::to_usize())
             .cloned()
             .collect();
+
+           
 
             *buf = right.iter().cloned().collect();
             Some(return_buf)

--- a/atat/src/helpers.rs
+++ b/atat/src/helpers.rs
@@ -67,33 +67,32 @@ pub fn get_line<L: ArrayLength<u8>, I: ArrayLength<u8>>(
         return None;
     }
 
-    
     let ind = if reverse {
         buf.windows(needle.len())
-        .rposition(|window| window == needle)
+            .rposition(|window| window == needle)
     } else {
         buf.windows(needle.len())
-        .position(|window| window == needle)
+            .position(|window| window == needle)
     };
-    
+
     #[cfg(test)]
     println!("{:?}", ind);
 
     match ind {
         Some(index) => {
             let white_space = buf
-            .iter()
-            .skip(index + needle.len())
-            .skip_while(|c| ![format_char, line_term_char, b'>', b'@'].contains(c))
-            .position(|c| ![format_char, line_term_char].contains(c))
-            .unwrap_or(buf.len() - index - needle.len());
-            
+                .iter()
+                .skip(index + needle.len())
+                .skip_while(|c| ![format_char, line_term_char, b'>', b'@'].contains(c))
+                .position(|c| ![format_char, line_term_char].contains(c))
+                .unwrap_or(buf.len() - index - needle.len());
+
             let (left, right) = match buf.split_at(index + needle.len() + white_space) {
                 (left, right) if !swap => (left, right),
                 (left, right) if swap => (right, left),
                 _ => return None,
             };
-            
+
             let return_buf = if trim_response {
                 left.trim(&[b'\t', b' ', format_char, line_term_char])
             } else {
@@ -104,8 +103,6 @@ pub fn get_line<L: ArrayLength<u8>, I: ArrayLength<u8>>(
             .take(L::to_usize())
             .cloned()
             .collect();
-
-           
 
             *buf = right.iter().cloned().collect();
             Some(return_buf)

--- a/atat/src/ingress_manager.rs
+++ b/atat/src/ingress_manager.rs
@@ -1,7 +1,7 @@
 use heapless::{consts, ArrayLength, Vec};
 
 use crate::atat_log;
-use crate::error::IngressError;
+use crate::error::InternalError;
 use crate::queues::{ComConsumer, ComItem, ResItem, ResProducer, UrcItem, UrcProducer};
 use crate::{Command, Config};
 
@@ -295,13 +295,13 @@ where
         // atat_log!(debug, "Received response: \"{:?}\"", data);
 
         if self.buf.extend_from_slice(data).is_err() {
-            self.notify_response(Err(IngressError::Overflow));
+            self.notify_response(Err(InternalError::Overflow));
         }
     }
 
     /// Notify the client that an appropriate response code, or error has been
     /// received
-    fn notify_response(&mut self, resp: Result<ByteVec<BufLen>, IngressError>) {
+    fn notify_response(&mut self, resp: Result<ByteVec<BufLen>, InternalError>) {
         match &resp {
             Ok(_r) => {
                 if _r.is_empty() {
@@ -574,7 +574,7 @@ where
                     false,
                     false,
                 ) {
-                    Err(IngressError::Error(
+                    Err(InternalError::Error(
                         get_line(
                             &mut line,
                             &[self.line_term_char],
@@ -764,7 +764,7 @@ mod test {
         }
         at_pars.write(b"\"\r\n");
         at_pars.digest();
-        assert_eq!(res_c.dequeue().unwrap(), Err(IngressError::Overflow));
+        assert_eq!(res_c.dequeue().unwrap(), Err(InternalError::Overflow));
         assert_eq!(at_pars.state, State::Idle);
     }
 
@@ -803,7 +803,7 @@ mod test {
         assert_eq!(at_pars.buf, Vec::<_, TestRxBufLen>::new());
         assert_eq!(
             res_c.dequeue().unwrap(),
-            Err(IngressError::Error(Vec::from_slice(b"ERROR").unwrap()))
+            Err(InternalError::Error(Vec::from_slice(b"ERROR").unwrap()))
         );
     }
 
@@ -828,7 +828,7 @@ mod test {
         assert_eq!(at_pars.buf, Vec::<_, TestRxBufLen>::new());
         assert_eq!(
             res_c.dequeue().unwrap(),
-            Err(IngressError::Error(Vec::from_slice(b"+CME ERROR: 123").unwrap()))
+            Err(InternalError::Error(Vec::from_slice(b"+CME ERROR: 123").unwrap()))
         );
     }
 
@@ -853,7 +853,7 @@ mod test {
         assert_eq!(at_pars.buf, Vec::<_, TestRxBufLen>::new());
         assert_eq!(
             res_c.dequeue().unwrap(),
-            Err(IngressError::Error(
+            Err(InternalError::Error(
                 Vec::from_slice(b"+CME ERROR: Operation not allowed").unwrap()
             ))
         );
@@ -880,9 +880,9 @@ mod test {
         assert_eq!(at_pars.buf, Vec::<_, TestRxBufLen>::new());
         assert_eq!(
             res_c.dequeue().unwrap(),
-            Err(IngressError::Error(
+            Err(InternalError::Error(
                 Vec::from_slice(
-                    b"+CME ERROR: Operation not allowed.. This is a very long error me"
+                    b"+CME ERROR: Operation not allowed.. This is a very long error message, that will neve"
                 )
                 .unwrap()
             ))

--- a/atat/src/ingress_manager.rs
+++ b/atat/src/ingress_manager.rs
@@ -88,7 +88,7 @@ where
     /// interrupt, or a DMA interrupt, to move data from the peripheral into the
     /// ingress manager receive buffer.
     pub fn write(&mut self, data: &[u8]) {
-        // defmt::trace!("Write: \"{=[u8]:a}\"", data);
+        defmt::trace!("Write: \"{=[u8]:a}\"", data);
 
         if self.buf.extend_from_slice(data).is_err() {
             defmt::error!(
@@ -132,7 +132,7 @@ where
                     defmt::debug!("Received response: \"{=[u8]:a}\"", &r);
                 }
             }
-            Err(_e) => defmt::error!("Received error response"),
+            Err(e) => defmt::error!("Received error response {:?}", e),
         }
         if self.res_p.ready() {
             unsafe { self.res_p.enqueue_unchecked(resp) };
@@ -160,9 +160,9 @@ where
         if let Some(com) = self.com_c.dequeue() {
             match com {
                 Command::Reset => {
+                    defmt::debug!("Cleared complete buffer as requested by client [{=[u8]:a}]", &self.buf);
                     self.digester.reset();
                     self.buf.clear();
-                    defmt::debug!("Cleared complete buffer as requested by client");
                 }
                 Command::ForceReceiveState => self.digester.force_receive_state(),
             }

--- a/atat/src/ingress_manager.rs
+++ b/atat/src/ingress_manager.rs
@@ -1,5 +1,5 @@
 use heapless::{consts, ArrayLength, Vec};
-
+use core::iter::FromIterator;
 use crate::atat_log;
 use crate::error::InternalError;
 use crate::queues::{ComConsumer, ComItem, ResItem, ResProducer, UrcItem, UrcProducer};

--- a/atat/src/ingress_manager.rs
+++ b/atat/src/ingress_manager.rs
@@ -160,7 +160,10 @@ where
         if let Some(com) = self.com_c.dequeue() {
             match com {
                 Command::Reset => {
-                    defmt::debug!("Cleared complete buffer as requested by client [{=[u8]:a}]", &self.buf);
+                    defmt::debug!(
+                        "Cleared complete buffer as requested by client [{=[u8]:a}]",
+                        &self.buf
+                    );
                     self.digester.reset();
                     self.buf.clear();
                 }

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! ### Command and response example without `atat_derive`:
 //! ```
-//! use atat::{AtatCmd, AtatResp, Error};
+//! use atat::{AtatCmd, AtatResp, Error, InternalError, GenericError};
 //! use core::fmt::Write;
 //! use heapless::{consts, String, Vec};
 //!
@@ -38,6 +38,7 @@
 //! impl<'a> AtatCmd for SetGreetingText<'a> {
 //!     type CommandLen = consts::U64;
 //!     type Response = NoResponse;
+//!     type Error = GenericError;
 //!
 //!     fn as_bytes(&self) -> Vec<u8, Self::CommandLen> {
 //!         let mut buf: Vec<u8, Self::CommandLen> = Vec::new();
@@ -45,7 +46,7 @@
 //!         buf
 //!     }
 //!
-//!     fn parse(&self, resp: &[u8]) -> Result<Self::Response, Error> {
+//!     fn parse(&self, resp: Result<&[u8], &InternalError>) -> Result<Self::Response, Error<Self::Error>> {
 //!         Ok(NoResponse)
 //!     }
 //! }
@@ -53,15 +54,16 @@
 //! impl AtatCmd for GetGreetingText {
 //!     type CommandLen = consts::U8;
 //!     type Response = GreetingText;
+//!     type Error = GenericError;
 //!
 //!     fn as_bytes(&self) -> Vec<u8, Self::CommandLen> {
 //!         Vec::from_slice(b"AT+CSGT?").unwrap()
 //!     }
 //!
-//!     fn parse(&self, resp: &[u8]) -> Result<Self::Response, Error> {
+//!     fn parse(&self, resp: Result<&[u8], &InternalError>) -> Result<Self::Response, Error<Self::Error>> {
 //!         // Parse resp into `GreetingText`
 //!         Ok(GreetingText {
-//!             text: String::from(core::str::from_utf8(resp).unwrap()),
+//!             text: String::from(core::str::from_utf8(resp.unwrap()).unwrap()),
 //!         })
 //!     }
 //! }

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -193,7 +193,7 @@
 //! #[interrupt]
 //! fn TIM7() {
 //!     let ingress = unsafe { INGRESS.as_mut().unwrap() };
-//!     ingress.parse_at();
+//!     ingress.digest();
 //! }
 //!
 //! #[interrupt]

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -94,7 +94,7 @@
 //!
 //! ### Basic usage example (More available in examples folder):
 //! ```ignore
-//! 
+//!
 //! use cortex_m::asm;
 //! use hal::{
 //!     gpio::{
@@ -258,7 +258,7 @@ pub use typenum;
 pub use heapless;
 
 pub use self::client::Client;
-pub use self::error::Error;
+pub use self::error::{Error, InternalError, GenericError};
 pub use self::ingress_manager::{
     get_line, IngressManager, NoopUrcMatcher, UrcMatcher, UrcMatcherResult,
 };

--- a/atat/src/queues.rs
+++ b/atat/src/queues.rs
@@ -3,12 +3,12 @@
 use heapless::spsc::{Consumer, Producer, Queue};
 use heapless::Vec;
 
-pub use crate::error::Error;
+pub use crate::error::IngressError;
 pub use crate::Command;
 
 // Queue item types
 pub type ComItem = Command;
-pub type ResItem<BufLen> = Result<Vec<u8, BufLen>, Error>;
+pub type ResItem<BufLen> = Result<Vec<u8, BufLen>, IngressError>;
 pub type UrcItem<BufLen> = Vec<u8, BufLen>;
 
 // Note: We could create a simple macro to define producer, consumer and queue,

--- a/atat/src/queues.rs
+++ b/atat/src/queues.rs
@@ -3,12 +3,12 @@
 use heapless::spsc::{Consumer, Producer, Queue};
 use heapless::Vec;
 
-pub use crate::error::IngressError;
+pub use crate::error::InternalError;
 pub use crate::Command;
 
 // Queue item types
 pub type ComItem = Command;
-pub type ResItem<BufLen> = Result<Vec<u8, BufLen>, IngressError>;
+pub type ResItem<BufLen> = Result<Vec<u8, BufLen>, InternalError>;
 pub type UrcItem<BufLen> = Vec<u8, BufLen>;
 
 // Note: We could create a simple macro to define producer, consumer and queue,

--- a/atat/src/traits.rs
+++ b/atat/src/traits.rs
@@ -33,7 +33,7 @@ pub trait AtatUrc {
 ///
 /// Example:
 /// ```
-/// use atat::{AtatCmd, AtatResp, Error};
+/// use atat::{AtatCmd, AtatResp, Error, InternalError, GenericError};
 /// use core::fmt::Write;
 /// use heapless::Vec;
 ///
@@ -48,6 +48,7 @@ pub trait AtatUrc {
 /// impl<'a> AtatCmd for SetGreetingText<'a> {
 ///     type CommandLen = heapless::consts::U64;
 ///     type Response = NoResponse;
+///     type Error = GenericError;
 ///
 ///     fn as_bytes(&self) -> Vec<u8, Self::CommandLen> {
 ///         let mut buf: Vec<u8, Self::CommandLen> = Vec::new();
@@ -55,7 +56,7 @@ pub trait AtatUrc {
 ///         buf
 ///     }
 ///
-///     fn parse(&self, resp: &[u8]) -> Result<Self::Response, Error> {
+///     fn parse(&self, resp: Result<&[u8], &InternalError>) -> Result<Self::Response, Error<Self::Error>> {
 ///         Ok(NoResponse)
 ///     }
 /// }

--- a/atat/src/traits.rs
+++ b/atat/src/traits.rs
@@ -1,9 +1,7 @@
-use crate::error::{Error, IngressError};
+use crate::error::{Error, InternalError};
 use crate::Mode;
 use core::str::FromStr;
 use heapless::{ArrayLength, Vec};
-
-pub trait AtatErr {}
 
 /// This trait needs to be implemented for every response type.
 ///
@@ -76,7 +74,7 @@ pub trait AtatCmd {
     type Response: AtatResp;
 
     /// The type of the error.
-    type Error: FromStr;
+    type Error: FromStr + defmt::Format;
 
     /// Return the command as a heapless `Vec` of bytes.
     fn as_bytes(&self) -> Vec<u8, Self::CommandLen>;
@@ -84,7 +82,7 @@ pub trait AtatCmd {
     /// Parse the response into a `Self::Response` or `Error<Self::Error>` instance.
     fn parse(
         &self,
-        resp: Result<&[u8], &IngressError>,
+        resp: Result<&[u8], &InternalError>,
     ) -> Result<Self::Response, Error<Self::Error>>;
 
     /// Whether or not this command can be aborted.

--- a/atat_derive/src/cmd.rs
+++ b/atat_derive/src/cmd.rs
@@ -72,7 +72,7 @@ pub fn atat_cmd(input: TokenStream) -> TokenStream {
     }
 
     let cmd_len_ident = format_ident!("U{}", cmd_len);
-    let err = error.unwrap_or_else(|| syn::parse_str("atat::error::GenericError").unwrap());
+    let err = error.unwrap_or_else(|| syn::parse_str("atat::GenericError").unwrap());
 
     let (field_names, field_names_str): (Vec<_>, Vec<_>) = variants
         .iter()
@@ -110,10 +110,10 @@ pub fn atat_cmd(input: TokenStream) -> TokenStream {
             }
 
             #[inline]
-            fn parse(&self, res: Result<&[u8], &atat::error::IngressError>) -> core::result::Result<Self::Response, atat::error::Error<Self::Error>> {
+            fn parse(&self, res: Result<&[u8], &atat::InternalError>) -> core::result::Result<Self::Response, atat::Error<Self::Error>> {
                 match res {
                     Ok(resp) => atat::serde_at::from_slice::<#resp>(resp).map_err(|e| {
-                        atat::error::Error::Parse
+                        atat::Error::Parse
                     }),
                     Err(e) => Err(e.into())
                 }

--- a/atat_derive/src/cmd.rs
+++ b/atat_derive/src/cmd.rs
@@ -17,6 +17,7 @@ pub fn atat_cmd(input: TokenStream) -> TokenStream {
     let CmdAttributes {
         cmd,
         resp,
+        error,
         timeout_ms,
         abortable,
         force_receive_state,
@@ -71,6 +72,7 @@ pub fn atat_cmd(input: TokenStream) -> TokenStream {
     }
 
     let cmd_len_ident = format_ident!("U{}", cmd_len);
+    let err = error.unwrap_or_else(|| syn::parse_str("atat::error::GenericError").unwrap());
 
     let (field_names, field_names_str): (Vec<_>, Vec<_>) = variants
         .iter()
@@ -91,6 +93,7 @@ pub fn atat_cmd(input: TokenStream) -> TokenStream {
         #[automatically_derived]
         impl #impl_generics atat::AtatCmd for #ident #ty_generics #where_clause {
             type Response = #resp;
+            type Error = #err;
             type CommandLen = <<Self as atat::AtatLen>::Len as core::ops::Add<::heapless::consts::#cmd_len_ident>>::Output;
 
             #[inline]
@@ -107,10 +110,13 @@ pub fn atat_cmd(input: TokenStream) -> TokenStream {
             }
 
             #[inline]
-            fn parse(&self, resp: &[u8]) -> core::result::Result<#resp, atat::Error> {
-                atat::serde_at::from_slice::<#resp>(resp).map_err(|e| {
-                    atat::Error::ParseString
-                })
+            fn parse(&self, res: Result<&[u8], &atat::error::IngressError>) -> core::result::Result<Self::Response, atat::error::Error<Self::Error>> {
+                match res {
+                    Ok(resp) => atat::serde_at::from_slice::<#resp>(resp).map_err(|e| {
+                        atat::error::Error::Parse
+                    }),
+                    Err(e) => Err(e.into())
+                }
             }
 
             #timeout

--- a/atat_derive/src/parse.rs
+++ b/atat_derive/src/parse.rs
@@ -19,6 +19,7 @@ pub struct ParseInput {
 pub struct CmdAttributes {
     pub cmd: String,
     pub resp: Path,
+    pub error: Option<Path>,
     pub timeout_ms: Option<u32>,
     pub abortable: Option<bool>,
     pub force_receive_state: Option<bool>,
@@ -253,6 +254,7 @@ impl Parse for CmdAttributes {
         let mut at_cmd = Self {
             cmd: cmd.value(),
             resp: response_ident,
+            error: None,
             timeout_ms: None,
             abortable: None,
             force_receive_state: None,
@@ -279,6 +281,13 @@ impl Parse for CmdAttributes {
                 match optional.lit {
                     Lit::Bool(v) => {
                         at_cmd.abortable = Some(v.value);
+                    }
+                    _ => return Err(Error::new(call_site, "expected bool value for 'abortable'")),
+                }
+            } else if optional.path.is_ident("error") {
+                match optional.lit {
+                    Lit::Str(v) => {
+                        at_cmd.error = Some(v.parse().unwrap());
                     }
                     _ => return Err(Error::new(call_site, "expected bool value for 'abortable'")),
                 }

--- a/atat_derive/src/urc.rs
+++ b/atat_derive/src/urc.rs
@@ -40,9 +40,7 @@ pub fn atat_urc(input: TokenStream) -> TokenStream {
                     panic!("cannot handle variants with more than one field")
                 }
                 quote! {
-                    #code => #ident::#variant_ident(atat::serde_at::from_slice::<#first_field>(&resp).map_err(|e| {
-                        atat::Error::ParseString
-                    })?),
+                    #code => #ident::#variant_ident(atat::serde_at::from_slice::<#first_field>(&resp[index..]).ok()?),
                 }
             }
             Some(Fields::Unit) => {
@@ -62,16 +60,16 @@ pub fn atat_urc(input: TokenStream) -> TokenStream {
             type Response = #ident;
 
             #[inline]
-            fn parse(resp: &[u8]) -> core::result::Result<Self::Response, atat::Error> {
+            fn parse(resp: &[u8]) -> Option<Self::Response> {
                 if let Some(index) = resp.iter().position(|&x| x == b':') {
-                    Ok(match &resp[..index] {
+                    Some(match &resp[..index] {
                         #(
                             #match_arms
                         )*
-                        _ => return Err(atat::Error::InvalidResponse)
+                        _ => return None
                     })
                 } else {
-                    Err(atat::Error::InvalidResponse)
+                    None
                 }
             }
         }

--- a/atat_derive/src/urc.rs
+++ b/atat_derive/src/urc.rs
@@ -35,12 +35,12 @@ pub fn atat_urc(input: TokenStream) -> TokenStream {
             }
             Some(Fields::Unnamed(f)) => {
                 let mut field_iter = f.unnamed.iter();
-                let first_field = field_iter.next().unwrap_or_else(|| panic!(""));
+                let first_field = field_iter.next().expect("variant must have exactly one field");
                 if field_iter.next().is_some() {
                     panic!("cannot handle variants with more than one field")
                 }
                 quote! {
-                    #code => #ident::#variant_ident(atat::serde_at::from_slice::<#first_field>(&resp[index..]).ok()?),
+                    #code => #ident::#variant_ident(atat::serde_at::from_slice::<#first_field>(&resp).ok()?),
                 }
             }
             Some(Fields::Unit) => {


### PR DESCRIPTION
This PR adds the ability to specify error types on each AT command

It does this by extending the `AtatCmd` trait with `type Error: FromStr + defmt::Format;`
If atat_derive is used, this will automatically set the error type to `GenericError` unless an error is defined as
```rust
#[derive(Debug, PartialEq, AtatCmd)]
#[at_cmd("+CFUN", NoResponse, error = "InnerError")]
struct ErrorTester {
    x: u8,
}
```

Once https://github.com/rust-lang/rust/issues/29661 lands, the default `GenericError` should be moved from the derive to the trait.


Fixes #87 
Fixes #85 