### PR TITLE
Change parameters of AtatCmd to associated consts

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,13 @@
+comment: no # do not comment PR with the result
+
+coverage:
+  range: 40..90 # coverage lower than 40 is red, higher than 90 green, between color code
+
+  status:
+    project: # settings affecting project coverage
+      default:
+        target: auto # auto % coverage target
+        threshold: 5%  # allow for 5% reduction of coverage without failing
+
+    # do not run coverage on patch nor changes
+    patch: false

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -83,4 +83,4 @@ jobs:
         with:
           # file: ${{ steps.grcov.outputs.report }}
           file: lcov.info
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/atat/src/helpers.rs
+++ b/atat/src/helpers.rs
@@ -75,9 +75,6 @@ pub fn get_line<L: ArrayLength<u8>, I: ArrayLength<u8>>(
             .position(|window| window == needle)
     };
 
-    #[cfg(test)]
-    println!("{:?}", ind);
-
     match ind {
         Some(index) => {
             let white_space = buf

--- a/atat/src/traits.rs
+++ b/atat/src/traits.rs
@@ -80,6 +80,21 @@ pub trait AtatCmd {
     /// The type of the error.
     type Error: FromStr + defmt::Format;
 
+    /// Whether or not this command can be aborted.
+    const CAN_ABORT: bool = false;
+
+    /// The max timeout in milliseconds.
+    const MAX_TIMEOUT_MS: u32 = 1000;
+
+    /// Force the ingress manager into receive state immediately after sending
+    /// the command.
+    const FORCE_RECEIVE_STATE: bool = false;
+
+    /// Force client to look for a response.
+    /// Empty slice is then passed to parse by client.
+    /// Implemented to enhance expandability fo ATAT
+    const EXPECTS_RESPONSE_CODE: bool = true;
+
     /// Return the command as a heapless `Vec` of bytes.
     fn as_bytes(&self) -> Vec<u8, Self::CommandLen>;
 
@@ -88,29 +103,6 @@ pub trait AtatCmd {
         &self,
         resp: Result<&[u8], &InternalError>,
     ) -> Result<Self::Response, Error<Self::Error>>;
-
-    /// Whether or not this command can be aborted.
-    fn can_abort(&self) -> bool {
-        false
-    }
-
-    /// The max timeout in milliseconds.
-    fn max_timeout_ms(&self) -> u32 {
-        1000
-    }
-
-    /// Force the ingress manager into receive state immediately after sending
-    /// the command.
-    fn force_receive_state(&self) -> bool {
-        false
-    }
-
-    /// Force client to look for a response.
-    /// Empty slice is then passed to parse by client.
-    /// Implemented to enhance expandability fo ATAT
-    fn expects_response_code(&self) -> bool {
-        true
-    }
 }
 
 pub trait AtatClient {

--- a/atat_derive/src/cmd.rs
+++ b/atat_derive/src/cmd.rs
@@ -35,9 +35,7 @@ pub fn atat_cmd(input: TokenStream) -> TokenStream {
     let timeout = match timeout_ms {
         Some(timeout_ms) => {
             quote! {
-                fn max_timeout_ms(&self) -> u32 {
-                    #timeout_ms
-                }
+                const MAX_TIMEOUT_MS: u32 = #timeout_ms;
             }
         }
         None => quote! {},
@@ -46,9 +44,7 @@ pub fn atat_cmd(input: TokenStream) -> TokenStream {
     let abortable = match abortable {
         Some(abortable) => {
             quote! {
-                fn can_abort(&self) -> bool {
-                    #abortable
-                }
+                const CAN_ABORT: bool = #abortable;
             }
         }
         None => quote! {},
@@ -57,9 +53,7 @@ pub fn atat_cmd(input: TokenStream) -> TokenStream {
     let force_receive = match force_receive_state {
         Some(force_receive_state) => {
             quote! {
-                fn force_receive_state(&self) -> bool {
-                    #force_receive_state
-                }
+                const FORCE_RECEIVE_STATE: bool = #force_receive_state;
             }
         }
         None => quote! {},
@@ -96,6 +90,12 @@ pub fn atat_cmd(input: TokenStream) -> TokenStream {
             type Error = #err;
             type CommandLen = <<Self as atat::AtatLen>::Len as core::ops::Add<::heapless::consts::#cmd_len_ident>>::Output;
 
+            #timeout
+
+            #abortable
+
+            #force_receive
+
             #[inline]
             fn as_bytes(&self) -> atat::heapless::Vec<u8, Self::CommandLen> {
                 let s: atat::heapless::String<::heapless::consts::#subcmd_len_ident> = atat::heapless::String::from(#cmd);
@@ -118,12 +118,6 @@ pub fn atat_cmd(input: TokenStream) -> TokenStream {
                     Err(e) => Err(e.into())
                 }
             }
-
-            #timeout
-
-            #abortable
-
-            #force_receive
         }
 
         #[automatically_derived]


### PR DESCRIPTION
Change AtatCmd to be associated consts rather than functions:
- `can_abort`
- `max_timeout_ms`
- `force_receive_state`
- `expects_response_code` 

Fixes #88 