### PR TITLE
Fix heapless string becoming zero length

### DIFF
--- a/atat_derive/src/cmd.rs
+++ b/atat_derive/src/cmd.rs
@@ -59,7 +59,7 @@ pub fn atat_cmd(input: TokenStream) -> TokenStream {
         None => quote! {},
     };
 
-    let subcmd_len = cmd.len();
+    let subcmd_len = cmd.len().max(1);
     let mut cmd_len = cmd_prefix.len() + cmd.len() + termination.len();
     if value_sep {
         cmd_len += 1;


### PR DESCRIPTION
Fix issue where zero length at commands results on a heapless::String of length 0, not allowed in const-generics version