### PR TITLE
Implement serde::StdError for both no_std & std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
           # version: latest
           # use-tool-cache: true
           command: install
-          args: grcov --git https://github.com/mozilla/grcov
+          args: --locked grcov --git https://github.com/mozilla/grcov
 
       - name: Test
         uses: actions-rs/cargo@v1

--- a/serde_at/Cargo.toml
+++ b/serde_at/Cargo.toml
@@ -13,10 +13,7 @@ version = "0.13.2-alpha.0"
 
 [dependencies]
 heapless = { version = "^0.7", features = ["serde"] }
-
-[dependencies.serde]
-default-features = false
-version = "^1"
+serde = { version = "^1", default-features = false }
 
 [dev-dependencies]
 serde_derive = "^1"

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -48,11 +48,13 @@ pub type Result<T> = core::result::Result<T, Error>;
 pub struct CharVec<const N: usize>(pub heapless::Vec<char, N>);
 
 impl<const N: usize> CharVec<N> {
+    /// Instantiate a new `CharVec` of capacity `N`
     #[must_use]
     pub fn new() -> Self {
         Self(heapless::Vec::<char, N>::new())
     }
 
+    /// Convert from `CharVec` to `String`
     #[must_use]
     pub fn to_string(&self) -> heapless::String<N> {
         let mut str = heapless::String::new();
@@ -121,7 +123,6 @@ impl<'de, const N: usize> Deserialize<'de> for CharVec<N> {
 }
 
 /// This type represents all possible errors that can occur when deserializing AT Command strings
-#[allow(clippy::pub_enum_variant_names)]
 #[derive(Debug, PartialEq)]
 #[non_exhaustive]
 pub enum Error {
@@ -253,7 +254,7 @@ impl<'a> Deserializer<'a> {
         loop {
             if let Some(c) = self.peek() {
                 if (c as char).is_alphanumeric() || (c as char).is_whitespace() {
-                    self.eat_char()
+                    self.eat_char();
                 } else {
                     return Err(Error::EofWhileParsingString);
                 }
@@ -576,9 +577,9 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
 
         visitor
             .visit_bytes(&self.slice[self.index..self.index + idx])
-            .and_then(|r| {
+            .map(|r| {
                 self.index += idx;
-                Ok(r)
+                r
             })
     }
 
@@ -743,6 +744,8 @@ impl de::Error for Error {
     }
 }
 
+impl de::StdError for Error {}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -774,9 +777,6 @@ impl fmt::Display for Error {
         )
     }
 }
-
-#[cfg(any(test, feature = "std"))]
-impl std::error::Error for Error {}
 
 /// Deserializes an instance of type `T` from bytes of AT Response text
 pub fn from_slice<'a, T>(v: &'a [u8]) -> Result<T>

--- a/serde_at/src/lib.rs
+++ b/serde_at/src/lib.rs
@@ -1,11 +1,13 @@
-// #![deny(missing_docs)]
+//! Serde serializer/deserializer for AT commands
+
+#![deny(missing_docs)]
 #![deny(rust_2018_compatibility)]
 #![deny(rust_2018_idioms)]
-// #![deny(warnings)]
+#![deny(warnings)]
 #![allow(clippy::multiple_crate_versions)]
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::missing_const_for_fn)]
-#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 
 pub mod de;
 pub mod ser;

--- a/serde_at/src/ser/mod.rs
+++ b/serde_at/src/ser/mod.rs
@@ -52,7 +52,7 @@ impl Deref for Bytes<'_> {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0
     }
 }
 
@@ -130,9 +130,6 @@ impl fmt::Display for Error {
         write!(f, "Buffer is full")
     }
 }
-
-#[cfg(any(test, feature = "std"))]
-impl std::error::Error for Error {}
 
 pub(crate) struct Serializer<'a, const B: usize> {
     buf: Vec<u8, B>,
@@ -319,7 +316,7 @@ impl<'a, 'b, const B: usize> ser::Serializer for &'a mut Serializer<'b, B> {
 
         // Temporary storage for encoded a single char.
         // A char is up to 4 bytes long wehn encoded to UTF-8.
-        let mut encoding_tmp = [0u8; 4];
+        let mut encoding_tmp = [0_u8; 4];
 
         for c in v.chars() {
             match c {
@@ -523,6 +520,8 @@ impl ser::Error for Error {
         unreachable!()
     }
 }
+
+impl ser::StdError for Error {}
 
 #[allow(clippy::empty_enum)]
 pub(crate) enum Unreachable {}


### PR DESCRIPTION
Implement `serde::{ser/de}::StdError` for both `no_std` & `std`, as it is exported in both cases.

Fixes #104 