### PR TITLE
use target.thumbv7em-none-eabihf.dev-dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: ["x86_64-unknown-linux-gnu", "thumbv7m-none-eabi"]
+        target: ["x86_64-unknown-linux-gnu", "thumbv7em-none-eabihf"]
         features:
           [
             "",
@@ -110,7 +110,7 @@ jobs:
           - target: "x86_64-unknown-linux-gnu"
             features: "derive, defmt-default"
             std: ", std"
-          - target: "thumbv7m-none-eabi"
+          - target: "thumbv7em-none-eabihf"
             examples: "--examples"
     steps:
       - name: Checkout source code
@@ -121,7 +121,7 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-          target: thumbv7m-none-eabi
+          target: thumbv7em-none-eabihf
           override: true
 
       - name: Build
@@ -141,7 +141,7 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-          target: thumbv7m-none-eabi
+          target: thumbv7em-none-eabihf
           override: true
       - name: Library tests
         uses: actions-rs/cargo@v1
@@ -167,7 +167,7 @@ jobs:
         with:
           profile: minimal
           toolchain: nightly
-          target: thumbv7m-none-eabi
+          target: thumbv7em-none-eabihf
           override: true
 
       - name: Install grcov

--- a/atat/Cargo.toml
+++ b/atat/Cargo.toml
@@ -30,7 +30,7 @@ bbqueue = "0.5"
 log = { version = "^0.4", default-features = false, optional = true }
 defmt = { version = "^0.2", optional = true }
 
-[dev-dependencies]
+[target.thumbv7em-none-eabihf.dev-dependencies]
 cortex-m = "0.7.1"
 cortex-m-rt = "0.6.13"
 cortex-m-rtic = "0.5.5"


### PR DESCRIPTION
Then dev-dependencies (examples) are built only for thumbv7em-none-eabihf.
This fixed #104 for me.

Now I can run `cargo test --tests` and everything builds and runs.
Without this I got:
```
   Compiling stm32l4 v0.12.1
   Compiling stm32l4xx-hal v0.5.0 (https://github.com/MathiasKoch/stm32l4xx-hal?branch=enhancement/prepare-embedded-hal-1.0#28490318)
LLVM ERROR: Global variable '__INTERRUPTS' has an invalid section specifier '.vector_table.interrupts': mach-o section specifier requires a segment and section separated by a comma.
error: could not compile `stm32l4`
warning: build failed, waiting for other jobs to finish...
error: build failed
```

Which makes sense, because those libs cannot be built for x86.