### PR TITLE
update deps, use fugit_timer::Timer instead of Clocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
             "",
             "derive",
             "derive, log",
-            "derive, defmt-default",
+            "derive, defmt",
           ]
         include:
           - target: "x86_64-unknown-linux-gnu"
@@ -108,7 +108,7 @@ jobs:
             features: "derive, log"
             std: ", std"
           - target: "x86_64-unknown-linux-gnu"
-            features: "derive, defmt-default"
+            features: "derive, defmt"
             std: ", std"
           - target: "thumbv7em-none-eabihf"
             examples: "--examples"

--- a/atat/Cargo.toml
+++ b/atat/Cargo.toml
@@ -18,8 +18,9 @@ name = "atat"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-embedded-hal = { version = "=1.0.0-alpha.4" }
-fugit = "0.3"
+embedded-hal = { version = "=1.0.0-alpha.6" }
+fugit = "0.3.3"
+fugit-timer = "0.1.2"
 nb = "^1"
 heapless = { version = "^0.7.0", features = ["serde"] }
 serde_at = { path = "../serde_at", version = "^0.14.0", optional = true }
@@ -29,7 +30,7 @@ heapless-bytes = { version = "0.3.0", optional = true }
 bbqueue = "0.5"
 
 log = { version = "^0.4", default-features = false, optional = true }
-defmt = { version = "^0.2", optional = true }
+defmt = { version = "^0.3", optional = true }
 
 [target.thumbv7em-none-eabihf.dev-dependencies]
 cortex-m = "0.7.1"
@@ -49,9 +50,3 @@ bytes = ["heapless-bytes", "serde_bytes"]
 
 std = ["serde_at/std"]
 
-defmt-default = ["defmt"]
-defmt-trace = ["defmt"]
-defmt-debug = ["defmt"]
-defmt-info = ["defmt"]
-defmt-warn = ["defmt"]
-defmt-error = ["defmt"]

--- a/atat/examples/cortex-m-rt.rs
+++ b/atat/examples/cortex-m-rt.rs
@@ -41,6 +41,10 @@ impl<TIM, const TIMER_HZ: u32> Clock<TIMER_HZ> for AtClock<TIM, TIMER_HZ> {
         Ok(())
     }
 
+    fn cancel(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
     fn wait(&mut self) -> nb::Result<(), Self::Error> {
         Ok(())
     }
@@ -138,7 +142,7 @@ fn TIM7() {
 fn USART2() {
     let ingress = unsafe { INGRESS.as_mut().unwrap() };
     let rx = unsafe { RX.as_mut().unwrap() };
-    if let Ok(d) = nb::block!(rx.try_read()) {
+    if let Ok(d) = nb::block!(rx.read()) {
         ingress.write(&[d]);
     }
 }

--- a/atat/examples/rtic.rs
+++ b/atat/examples/rtic.rs
@@ -37,6 +37,10 @@ impl<TIM, const TIMER_HZ: u32> Clock<TIMER_HZ> for AtClock<TIM, TIMER_HZ> {
         Ok(())
     }
 
+    fn cancel(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
     fn wait(&mut self) -> nb::Result<(), Self::Error> {
         Ok(())
     }
@@ -132,7 +136,7 @@ const APP: () = {
     #[task(binds = USART2, priority = 4, resources = [ingress, rx])]
     fn serial_irq(ctx: serial_irq::Context) {
         let rx = ctx.resources.rx;
-        if let Ok(d) = nb::block!(rx.try_read()) {
+        if let Ok(d) = nb::block!(rx.read()) {
             ctx.resources.ingress.write(&[d]);
         }
     }

--- a/atat/src/builder.rs
+++ b/atat/src/builder.rs
@@ -35,8 +35,8 @@ pub struct ClientBuilder<
     const RES_CAPACITY: usize,
     const URC_CAPACITY: usize,
 > where
-    Tx: embedded_hal::serial::Write<u8>,
-    CLK: super::Clock<TIMER_HZ>,
+    Tx: embedded_hal::serial::nb::Write<u8>,
+    CLK: fugit_timer::Timer<TIMER_HZ>,
     U: UrcMatcher,
     D: Digester,
 {
@@ -66,17 +66,16 @@ impl<
         URC_CAPACITY,
     >
 where
-    Tx: embedded_hal::serial::Write<u8>,
-    T: super::Clock<TIMER_HZ>,
+    Tx: embedded_hal::serial::nb::Write<u8>,
+    T: fugit_timer::Timer<TIMER_HZ>,
 {
     /// Create a builder for new Atat client instance.
     ///
     /// The `serial_tx` type must implement the `embedded_hal`
     /// [`serial::Write<u8>`][serialwrite] trait while the timer must implement
-    /// the [`Clock`][clock] trait.
+    /// the [`fugit_timer::Timer`] trait.
     ///
     /// [serialwrite]: ../embedded_hal/serial/trait.Write.html
-    /// [clock]: trait.Clock.html
     pub fn new(serial_tx: Tx, timer: T, config: Config) -> Self {
         Self {
             serial_tx,
@@ -99,8 +98,8 @@ impl<
         const URC_CAPACITY: usize,
     > ClientBuilder<Tx, CLK, U, D, TIMER_HZ, BUF_LEN, RES_CAPACITY, URC_CAPACITY>
 where
-    Tx: embedded_hal::serial::Write<u8>,
-    CLK: super::Clock<TIMER_HZ>,
+    Tx: embedded_hal::serial::nb::Write<u8>,
+    CLK: fugit_timer::Timer<TIMER_HZ>,
     U: UrcMatcher,
     D: Digester,
 {

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -207,18 +207,6 @@
 //!
 //! - **`derive`** *(enabled by default)* - Re-exports [`atat_derive`] to allow
 //!   deriving `Atat__` traits.
-//! - **`defmt-default`** *(disabled by default)* - Enable log statements at
-//!   INFO, or TRACE, level and up, to aid debugging. Powered by `defmt`.
-//! - **`defmt-trace`** *(disabled by default)* - Enable log statements at TRACE
-//!   level and up, to aid debugging. Powered by `defmt`.
-//! - **`defmt-debug`** *(disabled by default)* - Enable log statements at DEBUG
-//!   level and up, to aid debugging. Powered by `defmt`.
-//! - **`defmt-info`** *(disabled by default)* - Enable log statements at INFO
-//!   level and up, to aid debugging. Powered by `defmt`.
-//! - **`defmt-warn`** *(disabled by default)* - Enable log statements at WARN
-//!   level and up, to aid debugging. Powered by `defmt`.
-//! - **`defmt-error`** *(disabled by default)* - Enable log statements at ERROR
-//!   level and up, to aid debugging. Powered by `defmt`.
 
 // #![deny(warnings)]
 #![allow(clippy::multiple_crate_versions)]
@@ -274,25 +262,7 @@ pub use queues::{ComQueue, Queues};
 pub use traits::{AtatClient, AtatCmd, AtatResp, AtatUrc};
 pub use urc_matcher::{DefaultUrcMatcher, UrcMatcher, UrcMatcherResult};
 
-/// For timing `atat` uses [fugit](https://lib.rs/crates/fugit) crate which only provides `Duration` and `Instant` types.
-/// It does not provide any clock or timer traits.
-/// Therefore `atat` has its own `Clock` trait that provides all timing capabilities that are needed for the library.
-/// User must implement this trait for the timer by itself.
-pub trait Clock<const TIMER_HZ: u32> {
-    /// An error that might happen during waiting
-    type Error;
-
-    /// Return current time `Instant`
-    fn now(&mut self) -> fugit::TimerInstantU32<TIMER_HZ>;
-
-    /// Start countdown with a `duration`
-    fn start(&mut self, duration: fugit::TimerDurationU32<TIMER_HZ>) -> Result<(), Self::Error>;
-
-    /// Wait until countdown `duration` has expired.
-    /// Must return `nb::Error::WouldBlock` if countdown `duration` is not yet over.
-    /// Must return `OK(())` as soon as countdown `duration` has expired.
-    fn wait(&mut self) -> nb::Result<(), Self::Error>;
-}
+pub use fugit_timer::Timer as Clock;
 
 /// Commands that can be sent from the client to the ingress manager, for
 /// configuration after initial setup. This is also used for stuff like clearing

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -266,7 +266,7 @@ impl<'a> Deserializer<'a> {
 
     fn parse_at(&mut self) -> Result<Option<()>> {
         // If we find a '+', check if it is an AT command identifier, ending in ':'
-        if let Some(b'+') = self.parse_whitespace() {
+        if self.parse_whitespace() == Some(b'+') {
             let index = self.index;
             loop {
                 match self.peek() {


### PR DESCRIPTION
I've moved `Clocks` in separate crate as it's too hard to implement it in HALs during this part of `atat`.
In other side it can't be a part of `embedded-hal` as `fugit` primitives are only one of possible solutions. 