### PR TITLE
Ser/De hex strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ lcov.info
 
 # Ignore lock file in libraries (https://doc.rust-lang.org/cargo/faq.html#why-do-binaries-have-cargolock-in-version-control-but-not-libraries)
 Cargo.lock
+*.iml
+*.idea/

--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -789,16 +789,16 @@ mod test {
         #[derive(Clone, PartialEq, AtatCmd)]
         #[at_cmd("+DEVEUI", NoResponse, quote_escape_strings = false)]
         pub struct WithoutQuoteHexStr {
-            pub val: HexStr<u16>,
+            pub val: HexStr<u128>,
         }
 
         let val = HexStr {
-            val: 0xA0F5,
+            val: 0xA0F5_A0F5_A0F5_A0F5_A0F5_A0F5_A0F5_A0F5,
             ..Default::default()
         };
         let val = WithoutQuoteHexStr { val };
         let b = val.as_bytes();
         let s = core::str::from_utf8(&b).unwrap();
-        assert_eq!(s, "AT+DEVEUI=A0F5\r\n");
+        assert_eq!(s, "AT+DEVEUI=A0F5A0F5A0F5A0F5A0F5A0F5A0F5A0F5\r\n");
     }
 }

--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -757,6 +757,21 @@ mod test {
     #[test]
     fn quote_and_no_quote_strings() {
         #[derive(Clone, PartialEq, AtatCmd)]
+        #[at_cmd("+DEVEUI", NoResponse)]
+        pub struct WithQuoteNoValHexStr {
+            pub val: HexStr<u16>,
+        }
+
+        let val = HexStr {
+            val: 0xA0F5,
+            ..Default::default()
+        };
+        let val = WithQuoteNoValHexStr { val };
+        let b = val.as_bytes();
+        let s = core::str::from_utf8(&b).unwrap();
+        assert_eq!(s, "AT+DEVEUI=\"A0F5\"\r\n");
+
+        #[derive(Clone, PartialEq, AtatCmd)]
         #[at_cmd("+DEVEUI", NoResponse, quote_escape_strings = true)]
         pub struct WithQuoteHexStr {
             pub val: HexStr<u16>,
@@ -764,7 +779,7 @@ mod test {
 
         let val = HexStr {
             val: 0xA0F5,
-            .. Default::default()
+            ..Default::default()
         };
         let val = WithQuoteHexStr { val };
         let b = val.as_bytes();
@@ -779,7 +794,7 @@ mod test {
 
         let val = HexStr {
             val: 0xA0F5,
-            .. Default::default()
+            ..Default::default()
         };
         let val = WithoutQuoteHexStr { val };
         let b = val.as_bytes();

--- a/atat/src/derive.rs
+++ b/atat/src/derive.rs
@@ -1,4 +1,5 @@
 use heapless::{String, Vec};
+use serde_at::HexStr;
 
 /// Trait used by [`atat_derive`] to estimate lengths of the serialized commands, at compile time.
 ///
@@ -37,6 +38,12 @@ impl_length!(i64, 20);
 impl_length!(i128, 40);
 impl_length!(f32, 42);
 impl_length!(f64, 312);
+
+impl_length!(HexStr<u8>, 8);
+impl_length!(HexStr<u16>, 12);
+impl_length!(HexStr<u32>, 20);
+impl_length!(HexStr<u64>, 36);
+impl_length!(HexStr<u128>, 68);
 
 impl<const T: usize> AtatLen for String<T> {
     const LEN: usize = T;
@@ -163,6 +170,13 @@ mod tests {
 
         assert_eq!(<SimpleEnum as AtatLen>::LEN, 3);
         assert_eq!(<SimpleEnumU32 as AtatLen>::LEN, 10);
+
+        assert_eq!(<Hex<u8> as AtatLen>::LEN, 8);
+        assert_eq!(<Hex<u16> as AtatLen>::LEN, 12);
+        assert_eq!(<Hex<u32> as AtatLen>::LEN, 20);
+        assert_eq!(<Hex<u64> as AtatLen>::LEN, 36);
+        assert_eq!(<Hex<u128> as AtatLen>::LEN, 68);
+
         // (fields) + (n_fields - 1)
         // (3 + 128 + 2 + 150 + 3 + 10 + 3 + (10*5)) + 7
         assert_eq!(

--- a/atat/src/derive.rs
+++ b/atat/src/derive.rs
@@ -39,11 +39,13 @@ impl_length!(i128, 40);
 impl_length!(f32, 42);
 impl_length!(f64, 312);
 
-impl_length!(HexStr<u8>, 8);
-impl_length!(HexStr<u16>, 12);
-impl_length!(HexStr<u32>, 20);
-impl_length!(HexStr<u64>, 36);
-impl_length!(HexStr<u128>, 68);
+//       0x   F:F:F:F
+// uN = (2 + (N/2) - 1) * 2 bytes
+impl_length!(HexStr<u8>, 10);
+impl_length!(HexStr<u16>, 18);
+impl_length!(HexStr<u32>, 30);
+impl_length!(HexStr<u64>, 66);
+impl_length!(HexStr<u128>, 130);
 
 impl<const T: usize> AtatLen for String<T> {
     const LEN: usize = T;
@@ -171,11 +173,11 @@ mod tests {
         assert_eq!(<SimpleEnum as AtatLen>::LEN, 3);
         assert_eq!(<SimpleEnumU32 as AtatLen>::LEN, 10);
 
-        assert_eq!(<HexStr<u8> as AtatLen>::LEN, 8);
-        assert_eq!(<HexStr<u16> as AtatLen>::LEN, 12);
-        assert_eq!(<HexStr<u32> as AtatLen>::LEN, 20);
-        assert_eq!(<HexStr<u64> as AtatLen>::LEN, 36);
-        assert_eq!(<HexStr<u128> as AtatLen>::LEN, 68);
+        assert_eq!(<HexStr<u8> as AtatLen>::LEN, 10);
+        assert_eq!(<HexStr<u16> as AtatLen>::LEN, 18);
+        assert_eq!(<HexStr<u32> as AtatLen>::LEN, 30);
+        assert_eq!(<HexStr<u64> as AtatLen>::LEN, 66);
+        assert_eq!(<HexStr<u128> as AtatLen>::LEN, 130);
 
         // (fields) + (n_fields - 1)
         // (3 + 128 + 2 + 150 + 3 + 10 + 3 + (10*5)) + 7

--- a/atat/src/derive.rs
+++ b/atat/src/derive.rs
@@ -72,7 +72,7 @@ mod tests {
     use atat::{derive::AtatLen, AtatCmd};
     use atat_derive::{AtatCmd, AtatEnum, AtatResp};
     use heapless::{String, Vec};
-    use serde_at::{from_str, to_string, SerializeOptions};
+    use serde_at::{from_str, to_string, HexStr, SerializeOptions};
 
     macro_rules! assert_not_impl {
         ($x:ty, $($t:path),+ $(,)*) => {
@@ -171,11 +171,11 @@ mod tests {
         assert_eq!(<SimpleEnum as AtatLen>::LEN, 3);
         assert_eq!(<SimpleEnumU32 as AtatLen>::LEN, 10);
 
-        assert_eq!(<Hex<u8> as AtatLen>::LEN, 8);
-        assert_eq!(<Hex<u16> as AtatLen>::LEN, 12);
-        assert_eq!(<Hex<u32> as AtatLen>::LEN, 20);
-        assert_eq!(<Hex<u64> as AtatLen>::LEN, 36);
-        assert_eq!(<Hex<u128> as AtatLen>::LEN, 68);
+        assert_eq!(<HexStr<u8> as AtatLen>::LEN, 8);
+        assert_eq!(<HexStr<u16> as AtatLen>::LEN, 12);
+        assert_eq!(<HexStr<u32> as AtatLen>::LEN, 20);
+        assert_eq!(<HexStr<u64> as AtatLen>::LEN, 36);
+        assert_eq!(<HexStr<u128> as AtatLen>::LEN, 68);
 
         // (fields) + (n_fields - 1)
         // (3 + 128 + 2 + 150 + 3 + 10 + 3 + (10*5)) + 7

--- a/atat/src/helpers.rs
+++ b/atat/src/helpers.rs
@@ -5,7 +5,7 @@ pub struct LossyStr<'a>(pub &'a [u8]);
 impl<'a> core::fmt::Debug for LossyStr<'a> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match core::str::from_utf8(self.0) {
-            Ok(s) => write!(f, "{:?}", s),
+            Ok(s) => write!(f, "{s:?}"),
             Err(_) => write!(f, "{:?}", self.0),
         }
     }

--- a/atat_derive/src/cmd.rs
+++ b/atat_derive/src/cmd.rs
@@ -59,7 +59,7 @@ pub fn atat_cmd(input: TokenStream) -> TokenStream {
         None => quote! {},
     };
 
-    let quote_escape_strings = !matches!(quote_escape_strings, Some(false));
+    // let quote_escape_strings = !matches!(quote_escape_strings, Some(false));
 
     let mut cmd_len = cmd_prefix.len() + cmd.len() + termination.len();
     if value_sep {
@@ -101,9 +101,6 @@ pub fn atat_cmd(input: TokenStream) -> TokenStream {
 
             #[inline]
             fn as_bytes(&self) -> atat::heapless::Vec<u8, { #ident_len + #cmd_len }> {
-                if !#quote_escape_strings {
-                    panic!("As bytes false");
-                }
                 match atat::serde_at::to_vec(self, #cmd, atat::serde_at::SerializeOptions {
                     value_sep: #value_sep,
                     cmd_prefix: #cmd_prefix,

--- a/atat_derive/src/cmd.rs
+++ b/atat_derive/src/cmd.rs
@@ -23,6 +23,7 @@ pub fn atat_cmd(input: TokenStream) -> TokenStream {
         value_sep,
         cmd_prefix,
         termination,
+        quote_escape_strings,
     } = at_cmd.expect("missing #[at_cmd(...)] attribute");
 
     let ident_str = ident.to_string();
@@ -58,9 +59,14 @@ pub fn atat_cmd(input: TokenStream) -> TokenStream {
         None => quote! {},
     };
 
+    let quote_escape_strings = !matches!(quote_escape_strings, Some(false));
+
     let mut cmd_len = cmd_prefix.len() + cmd.len() + termination.len();
     if value_sep {
         cmd_len += 1;
+    }
+    if quote_escape_strings {
+        cmd_len += 2;
     }
 
     let (field_names, field_names_str): (Vec<_>, Vec<_>) = variants
@@ -98,7 +104,8 @@ pub fn atat_cmd(input: TokenStream) -> TokenStream {
                 match atat::serde_at::to_vec(self, #cmd, atat::serde_at::SerializeOptions {
                     value_sep: #value_sep,
                     cmd_prefix: #cmd_prefix,
-                    termination: #termination
+                    termination: #termination,
+                    quote_escape_strings: #quote_escape_strings
                 }) {
                     Ok(s) => s,
                     Err(_) => panic!("Failed to serialize command")

--- a/atat_derive/src/cmd.rs
+++ b/atat_derive/src/cmd.rs
@@ -101,6 +101,9 @@ pub fn atat_cmd(input: TokenStream) -> TokenStream {
 
             #[inline]
             fn as_bytes(&self) -> atat::heapless::Vec<u8, { #ident_len + #cmd_len }> {
+                if !#quote_escape_strings {
+                    panic!("As bytes false");
+                }
                 match atat::serde_at::to_vec(self, #cmd, atat::serde_at::SerializeOptions {
                     value_sep: #value_sep,
                     cmd_prefix: #cmd_prefix,

--- a/atat_derive/src/enum_.rs
+++ b/atat_derive/src/enum_.rs
@@ -58,7 +58,7 @@ pub fn atat_enum(input: TokenStream) -> TokenStream {
     let visitor = format_ident!("{}Visitor", ident);
     let field_visitor = format_ident!("{}FieldVisitor", ident);
     let invalid_val_err = format!("field index {} <= i < {}", 0, len);
-    let enum_name = format!("enum {}", ident);
+    let enum_name = format!("enum {ident}");
 
     let mut deserialize_generics = syn::Generics::default();
     let mut serialize_generics = syn::Generics::default();

--- a/atat_derive/src/helpers.rs
+++ b/atat_derive/src/helpers.rs
@@ -88,9 +88,9 @@ pub fn deserialize_struct(ident: &Ident, variants: &[Variant], generics: &Generi
     let field_names_bytestr = field_names_str
         .iter()
         .map(|a| Literal::byte_string(a.as_bytes()));
-    let invalid_len_err = format!("struct {} with {} elements", ident, len);
-    let invalid_val_err = format!("field index {} <= i < {}", 0, len);
-    let struct_name = format!("struct {}", ident);
+    let invalid_len_err = format!("struct {ident} with {len} elements");
+    let invalid_val_err = format!("field index 0 <= i < {len}");
+    let struct_name = format!("struct {ident}");
 
     let (_, ty_generics, _) = generics.split_for_impl();
     let mut serde_generics = generics.clone();

--- a/atat_derive/src/lib.rs
+++ b/atat_derive/src/lib.rs
@@ -153,6 +153,7 @@ pub fn derive_atat_enum(input: TokenStream) -> TokenStream {
 ///   'AT'). Can also be set to '' (empty).
 /// - `termination`: **string** Overwrite the line termination of the command
 ///   (default '\r\n'). Can also be set to '' (empty).
+/// - `quote_escape_strings`: **bool** Whether to escape strings in commands (default true).
 ///
 /// ### Field attribute (`#[at_arg(..)]`)
 /// The `AtatCmd` derive macro comes with an optional field attribute

--- a/atat_derive/src/parse.rs
+++ b/atat_derive/src/parse.rs
@@ -25,7 +25,8 @@ pub struct CmdAttributes {
     pub value_sep: bool,
     pub cmd_prefix: String,
     pub termination: String,
-    pub quote_escape_strings: Option<bool>,
+    // pub quote_escape_strings: Option<bool>,
+    pub quote_escape_strings: bool,
 }
 /// Parsed attributes of `#[at_arg(..)]`
 #[derive(Clone)]
@@ -260,7 +261,7 @@ impl Parse for CmdAttributes {
             value_sep: true,
             cmd_prefix: String::from("AT"),
             termination: String::from("\r\n"),
-            quote_escape_strings: None,
+            quote_escape_strings: true,
         };
 
         while input.parse::<syn::token::Comma>().is_ok() {
@@ -324,6 +325,18 @@ impl Parse for CmdAttributes {
                         return Err(Error::new(
                             call_site,
                             "expected string value for 'termination'",
+                        ))
+                    }
+                }
+            } else if optional.path.is_ident("quote_escape_strings") {
+                match optional.lit {
+                    Lit::Bool(v) => {
+                        at_cmd.quote_escape_strings = v.value;
+                    }
+                    _ => {
+                        return Err(Error::new(
+                            call_site,
+                            "expected bool value for 'quote_escape_strings'",
                         ))
                     }
                 }

--- a/atat_derive/src/parse.rs
+++ b/atat_derive/src/parse.rs
@@ -25,6 +25,7 @@ pub struct CmdAttributes {
     pub value_sep: bool,
     pub cmd_prefix: String,
     pub termination: String,
+    pub quote_escape_strings: Option<bool>,
 }
 /// Parsed attributes of `#[at_arg(..)]`
 #[derive(Clone)]
@@ -259,6 +260,7 @@ impl Parse for CmdAttributes {
             value_sep: true,
             cmd_prefix: String::from("AT"),
             termination: String::from("\r\n"),
+            quote_escape_strings: None
         };
 
         while input.parse::<syn::token::Comma>().is_ok() {

--- a/atat_derive/src/parse.rs
+++ b/atat_derive/src/parse.rs
@@ -260,7 +260,7 @@ impl Parse for CmdAttributes {
             value_sep: true,
             cmd_prefix: String::from("AT"),
             termination: String::from("\r\n"),
-            quote_escape_strings: None
+            quote_escape_strings: None,
         };
 
         while input.parse::<syn::token::Comma>().is_ok() {

--- a/serde_at/Cargo.toml
+++ b/serde_at/Cargo.toml
@@ -15,6 +15,10 @@ version = "0.18.0"
 heapless = { version = "^0.7", features = ["serde"] }
 serde = { version = "^1", default-features = false }
 
+[dependencies.num-traits]
+version = "0.2"
+default-features = false
+
 [dev-dependencies]
 serde_derive = "^1"
 heapless-bytes = { version = "0.3.0" }

--- a/serde_at/src/de/hex_str.rs
+++ b/serde_at/src/de/hex_str.rs
@@ -37,7 +37,7 @@ where
             add_0x_with_encoding: false,
             hex_in_caps: true,
             delimiter_after_nibble_count: 0,
-            delimiter: ' '
+            delimiter: ' ',
         }
     }
 }

--- a/serde_at/src/de/hex_str.rs
+++ b/serde_at/src/de/hex_str.rs
@@ -1,0 +1,113 @@
+use core::fmt;
+use core::marker::PhantomData;
+use core::ops::{Deref, Shl};
+use serde::de::Visitor;
+use serde::*;
+
+struct HexLiteralVisitor<T> {
+    _ty: PhantomData<T>,
+}
+
+/// HexStr<T>
+/// A hex string. Has phantom data used in serializing whether to add a 0x to the encoding
+/// and to make the hex value in capital letters or not.
+#[derive(Clone, PartialEq)]
+pub struct HexStr<T> {
+    /// Value of the hex string. Can be dereferenced
+    pub val: T,
+    /// Flag to add 0x when serializing the value
+    pub add_0x_with_encoding: bool,
+    /// Flag to serialize the hex in capital letters
+    pub hex_in_caps: bool
+}
+
+impl <T> Default for HexStr<T>
+    where T: Default {
+    fn default() -> Self {
+        HexStr {
+            val: T::default(),
+            add_0x_with_encoding: false,
+            hex_in_caps: false
+        }
+    }
+}
+
+macro_rules! impl_hex_literal_visitor {
+    ($($int_type:ty)*) => {$(
+        impl<'de> Visitor<'de> for HexLiteralVisitor<$int_type> {
+            type Value = $int_type;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an unsigned integer in hexadecimal notation")
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let mut s = core::str::from_utf8(v)
+                    .map_err(serde::de::Error::custom)?;
+                if s.starts_with("0x") || s.starts_with("0X") {
+                    s = &s[2..];
+                }
+
+                let mut ret: $int_type = 0;
+
+                for c in s.chars() {
+                    let v = match c {
+                        '0'..='9' => (c as $int_type) - ('0' as $int_type),
+                        'A'..='F' => 0xa + ((c as $int_type) - ('A' as $int_type)),
+                        'a'..='f' => 0xa + ((c as $int_type) - ('a' as $int_type)),
+                        _ => 0
+                    };
+
+                    ret = ret
+                        .shl(4i32)
+                        .checked_add(v)
+                        .ok_or(serde::de::Error::custom("Invalid number"))?;
+                }
+
+                Ok(ret)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for HexStr<$int_type> {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+            {
+                let val = deserializer.deserialize_bytes(HexLiteralVisitor::<$int_type> { _ty: PhantomData })?;
+                Ok(HexStr { val, ..Default::default() })
+            }
+        }
+
+        impl Deref for HexStr<$int_type> {
+            type Target = $int_type;
+
+            fn deref(&self) -> &Self::Target {
+                &self.val
+            }
+        }
+    )*}
+}
+
+impl_hex_literal_visitor! { u8 u16 u32 u64 u128 }
+
+#[cfg(test)]
+mod tests {
+    use crate::de::hex_str::HexStr;
+
+    #[test]
+    pub fn test_parsing_a_hex_string() {
+        let val: HexStr<u8> = crate::from_str("+CCID: 0x8d").unwrap();
+        assert_eq!(*val, 0x8d);
+        let val: HexStr<u16> = crate::from_str("+CCID: 0x0B00").unwrap();
+        assert_eq!(*val, 0x0B00);
+        let val: HexStr<u32> = crate::from_str("+CCID: D3AdB3ef").unwrap();
+        assert_eq!(*val, 0xd3adb3ef);
+        let val: HexStr<u64> = crate::from_str("+CCID: 0xFeedfACECAfeBE3F").unwrap();
+        assert_eq!(*val, 0xFeedfACECAfeBE3F);
+        let val: HexStr<u128> = crate::from_str("+CCID: 0x1234567890abcdef1234567890abcdef").unwrap();
+        assert_eq!(*val, 0x1234567890abcdef1234567890abcdef);
+    }
+}

--- a/serde_at/src/de/hex_str.rs
+++ b/serde_at/src/de/hex_str.rs
@@ -21,9 +21,9 @@ pub struct HexStr<T> {
     pub add_0x_with_encoding: bool,
     /// Flag to serialize the hex in capital letters
     pub hex_in_caps: bool,
-    /// Flag to split every n amount of bytes with a delimiter
+    /// Flag to split every n amount of nibbles with a delimiter
     pub delimiter_after_nibble_count: usize,
-    /// Split every n amount of bytes with this delimiter
+    /// Split every n amount of nibbles with this delimiter
     pub delimiter: char,
 }
 

--- a/serde_at/src/de/hex_str.rs
+++ b/serde_at/src/de/hex_str.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use core::fmt::Debug;
 use core::marker::PhantomData;
 use core::ops::{Deref, Shl};
 use serde::de::Visitor;

--- a/serde_at/src/de/hex_str.rs
+++ b/serde_at/src/de/hex_str.rs
@@ -18,16 +18,18 @@ pub struct HexStr<T> {
     /// Flag to add 0x when serializing the value
     pub add_0x_with_encoding: bool,
     /// Flag to serialize the hex in capital letters
-    pub hex_in_caps: bool
+    pub hex_in_caps: bool,
 }
 
-impl <T> Default for HexStr<T>
-    where T: Default {
+impl<T> Default for HexStr<T>
+where
+    T: Default,
+{
     fn default() -> Self {
         HexStr {
             val: T::default(),
             add_0x_with_encoding: false,
-            hex_in_caps: false
+            hex_in_caps: false,
         }
     }
 }
@@ -107,7 +109,8 @@ mod tests {
         assert_eq!(*val, 0xd3adb3ef);
         let val: HexStr<u64> = crate::from_str("+CCID: 0xFeedfACECAfeBE3F").unwrap();
         assert_eq!(*val, 0xFeedfACECAfeBE3F);
-        let val: HexStr<u128> = crate::from_str("+CCID: 0x1234567890abcdef1234567890abcdef").unwrap();
+        let val: HexStr<u128> =
+            crate::from_str("+CCID: 0x1234567890abcdef1234567890abcdef").unwrap();
         assert_eq!(*val, 0x1234567890abcdef1234567890abcdef);
     }
 }

--- a/serde_at/src/de/hex_str.rs
+++ b/serde_at/src/de/hex_str.rs
@@ -12,7 +12,7 @@ struct HexLiteralVisitor<T> {
 /// A hex string. Has fields used in serializing whether to add a 0x to the encoding
 /// and to make the hex value in capital letters or not.
 /// Can be dereferenced to its value.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct HexStr<T> {
     /// Value of the hex string. Can be dereferenced
     pub val: T,

--- a/serde_at/src/de/hex_str.rs
+++ b/serde_at/src/de/hex_str.rs
@@ -2,17 +2,17 @@ use core::fmt;
 use core::marker::PhantomData;
 use core::ops::{Deref, Shl};
 use serde::de::Visitor;
-use serde::*;
+use serde::{de, Deserialize};
 
 struct HexLiteralVisitor<T> {
     _ty: PhantomData<T>,
 }
 
-/// HexStr<T>
+/// `HexStr<T>`
 /// A hex string. Has fields used in serializing whether to add a 0x to the encoding
 /// and to make the hex value in capital letters or not.
 /// Can be dereferenced to its value.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct HexStr<T> {
     /// Value of the hex string. Can be dereferenced
     pub val: T,
@@ -27,7 +27,7 @@ where
     T: Default,
 {
     fn default() -> Self {
-        HexStr {
+        Self {
             val: T::default(),
             add_0x_with_encoding: false,
             hex_in_caps: true,

--- a/serde_at/src/de/hex_str.rs
+++ b/serde_at/src/de/hex_str.rs
@@ -58,7 +58,7 @@ macro_rules! impl_hex_literal_visitor {
                 for c in s.chars() {
                     let v = match c {
                         '0'..='9' => (c as $int_type) - ('0' as $int_type),
-                        'A'..='F' => 0xa + ((c as $int_type) - ('A' as $int_type)),
+                        'A'..='F' => 0xA + ((c as $int_type) - ('A' as $int_type)),
                         'a'..='f' => 0xa + ((c as $int_type) - ('a' as $int_type)),
                         _ => 0
                     };

--- a/serde_at/src/de/hex_str.rs
+++ b/serde_at/src/de/hex_str.rs
@@ -9,8 +9,9 @@ struct HexLiteralVisitor<T> {
 }
 
 /// HexStr<T>
-/// A hex string. Has phantom data used in serializing whether to add a 0x to the encoding
+/// A hex string. Has fields used in serializing whether to add a 0x to the encoding
 /// and to make the hex value in capital letters or not.
+/// Can be dereferenced to its value.
 #[derive(Clone, PartialEq)]
 pub struct HexStr<T> {
     /// Value of the hex string. Can be dereferenced

--- a/serde_at/src/de/hex_str.rs
+++ b/serde_at/src/de/hex_str.rs
@@ -30,7 +30,7 @@ where
         HexStr {
             val: T::default(),
             add_0x_with_encoding: false,
-            hex_in_caps: false,
+            hex_in_caps: true,
         }
     }
 }

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -13,6 +13,9 @@ mod enum_;
 mod map;
 mod seq;
 
+/// Hex string helper module
+pub mod hex_str;
+
 /// Deserialization result
 pub type Result<T> = core::result::Result<T, Error>;
 

--- a/serde_at/src/lib.rs
+++ b/serde_at/src/lib.rs
@@ -16,7 +16,7 @@ pub mod ser;
 pub use serde;
 
 #[doc(inline)]
-pub use self::de::{from_slice, from_str};
+pub use self::de::{from_slice, from_str, hex_str::HexStr};
 #[doc(inline)]
 pub use self::ser::{to_string, to_vec, SerializeOptions};
 

--- a/serde_at/src/ser/hex_str.rs
+++ b/serde_at/src/ser/hex_str.rs
@@ -1,31 +1,30 @@
-use serde::Serializer;
 use crate::HexStr;
-use serde::ser::{Serialize};
-use core::fmt::{Write, UpperHex, LowerHex};
-use std::ops::Deref;
+use core::fmt::{LowerHex, UpperHex, Write};
+use core::ops::Deref;
+use serde::ser::Serialize;
+use serde::Serializer;
 
-impl <T> Serialize for HexStr<T>
-    where
-        HexStr<T>: Deref + Sized,
-        <HexStr<T> as Deref>::Target: Sized + UpperHex + LowerHex + Copy
+impl<T> Serialize for HexStr<T>
+where
+    HexStr<T>: Deref + Sized,
+    <HexStr<T> as Deref>::Target: Sized + UpperHex + LowerHex + Copy,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer {
+    where
+        S: Serializer,
+    {
         let mut string = heapless::String::<20>::new();
         let val = **self;
         if self.add_0x_with_encoding {
             if self.hex_in_caps {
-                write!(string, "0x{:X}", val).unwrap();
+                write!(string, "0x{val:X}").unwrap();
             } else {
-                write!(string, "0x{:x}", val).unwrap();
+                write!(string, "0x{val:x}").unwrap();
             }
+        } else if self.hex_in_caps {
+            write!(string, "{val:X}").unwrap();
         } else {
-            if self.hex_in_caps {
-                write!(string, "{:X}", val).unwrap();
-            } else {
-                write!(string, "{:x}", val).unwrap();
-            }
+            write!(string, "{val:x}").unwrap();
         }
 
         serializer.serialize_str(string.as_str())

--- a/serde_at/src/ser/hex_str.rs
+++ b/serde_at/src/ser/hex_str.rs
@@ -5,8 +5,7 @@ use serde::Serializer;
 
 macro_rules! impl_hex_str_serialize {
     ($type:ty, $len:expr, $len_delimited:expr) => {
-        impl Serialize for HexStr<$type>
-        {
+        impl Serialize for HexStr<$type> {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
                 S: Serializer,

--- a/serde_at/src/ser/hex_str.rs
+++ b/serde_at/src/ser/hex_str.rs
@@ -1,0 +1,33 @@
+use serde::Serializer;
+use crate::HexStr;
+use serde::ser::{Serialize};
+use core::fmt::{Write, UpperHex, LowerHex};
+use std::ops::Deref;
+
+impl <T> Serialize for HexStr<T>
+    where
+        HexStr<T>: Deref + Sized,
+        <HexStr<T> as Deref>::Target: Sized + UpperHex + LowerHex + Copy
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer {
+        let mut string = heapless::String::<20>::new();
+        let val = **self;
+        if self.add_0x_with_encoding {
+            if self.hex_in_caps {
+                write!(string, "0x{:X}", val).unwrap();
+            } else {
+                write!(string, "0x{:x}", val).unwrap();
+            }
+        } else {
+            if self.hex_in_caps {
+                write!(string, "{:X}", val).unwrap();
+            } else {
+                write!(string, "{:x}", val).unwrap();
+            }
+        }
+
+        serializer.serialize_str(string.as_str())
+    }
+}

--- a/serde_at/src/ser/hex_str.rs
+++ b/serde_at/src/ser/hex_str.rs
@@ -1,55 +1,60 @@
 use crate::HexStr;
 use core::fmt::Write;
-use core::fmt::{LowerHex, UpperHex};
-use core::ops::Deref;
 use serde::ser::Serialize;
 use serde::Serializer;
 
-impl<T> Serialize for HexStr<T>
-where
-    Self: Deref + Sized,
-    <Self as Deref>::Target: Sized + UpperHex + LowerHex + Copy,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let val: <Self as Deref>::Target = **self;
-        if self.delimiter_after_nibble_count > 0 {
-            let mut string = heapless::String::<40>::new();
-            let mut placeholder = heapless::String::<40>::new();
-            if self.hex_in_caps {
-                write!(string, "{val:X}").unwrap();
-            } else {
-                write!(string, "{val:x}").unwrap();
-            }
+macro_rules! impl_hex_str_serialize {
+    ($type:ty, $len:expr, $len_delimited:expr) => {
+        impl Serialize for HexStr<$type>
+        {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                let val: $type = **self;
+                if self.delimiter_after_nibble_count > 0 {
+                    let mut string = heapless::String::<$len_delimited>::new();
+                    let mut placeholder = heapless::String::<$len_delimited>::new();
+                    if self.hex_in_caps {
+                        write!(string, "{val:X}").unwrap();
+                    } else {
+                        write!(string, "{val:x}").unwrap();
+                    }
 
-            for (index, c) in string.chars().rev().enumerate() {
-                if index != 0 && index % self.delimiter_after_nibble_count == 0 {
-                    placeholder.push(self.delimiter).unwrap();
+                    for (index, c) in string.chars().rev().enumerate() {
+                        if index != 0 && index % self.delimiter_after_nibble_count == 0 {
+                            placeholder.push(self.delimiter).unwrap();
+                        }
+                        placeholder.push(c).unwrap();
+                    }
+
+                    string.clear();
+                    if self.add_0x_with_encoding {
+                        string.push('0').unwrap();
+                        string.push('x').unwrap();
+                    }
+                    for c in placeholder.chars().rev() {
+                        string.push(c).unwrap();
+                    }
+
+                    serializer.serialize_str(string.as_str())
+                } else {
+                    let mut string = heapless::String::<$len>::new();
+                    match (self.add_0x_with_encoding, self.hex_in_caps) {
+                        (true, true) => write!(string, "0x{val:X}").unwrap(),
+                        (true, false) => write!(string, "0x{val:x}").unwrap(),
+                        (false, true) => write!(string, "{val:X}").unwrap(),
+                        (false, false) => write!(string, "{val:x}").unwrap(),
+                    }
+                    serializer.serialize_str(string.as_str())
                 }
-                placeholder.push(c).unwrap();
             }
-
-            string.clear();
-            if self.add_0x_with_encoding {
-                string.push('0').unwrap();
-                string.push('x').unwrap();
-            }
-            for c in placeholder.chars().rev() {
-                string.push(c).unwrap();
-            }
-
-            serializer.serialize_str(string.as_str())
-        } else {
-            let mut string = heapless::String::<20>::new();
-            match (self.add_0x_with_encoding, self.hex_in_caps) {
-                (true, true) => write!(string, "0x{val:X}").unwrap(),
-                (true, false) => write!(string, "0x{val:x}").unwrap(),
-                (false, true) => write!(string, "{val:X}").unwrap(),
-                (false, false) => write!(string, "{val:x}").unwrap(),
-            }
-            serializer.serialize_str(string.as_str())
         }
-    }
+    };
 }
+
+impl_hex_str_serialize!(u8, 8, 10);
+impl_hex_str_serialize!(u16, 12, 18);
+impl_hex_str_serialize!(u32, 20, 30);
+impl_hex_str_serialize!(u64, 36, 66);
+impl_hex_str_serialize!(u128, 68, 130);

--- a/serde_at/src/ser/hex_str.rs
+++ b/serde_at/src/ser/hex_str.rs
@@ -6,8 +6,8 @@ use serde::Serializer;
 
 impl<T> Serialize for HexStr<T>
 where
-    HexStr<T>: Deref + Sized,
-    <HexStr<T> as Deref>::Target: Sized + UpperHex + LowerHex + Copy,
+    Self: Deref + Sized,
+    <Self as Deref>::Target: Sized + UpperHex + LowerHex + Copy,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -15,16 +15,11 @@ where
     {
         let mut string = heapless::String::<20>::new();
         let val = **self;
-        if self.add_0x_with_encoding {
-            if self.hex_in_caps {
-                write!(string, "0x{val:X}").unwrap();
-            } else {
-                write!(string, "0x{val:x}").unwrap();
-            }
-        } else if self.hex_in_caps {
-            write!(string, "{val:X}").unwrap();
-        } else {
-            write!(string, "{val:x}").unwrap();
+        match (self.add_0x_with_encoding, self.hex_in_caps) {
+            (true, true) => write!(string, "0x{val:X}").unwrap(),
+            (true, false) => write!(string, "0x{val:x}").unwrap(),
+            (false, true) => write!(string, "{val:X}").unwrap(),
+            (false, false) => write!(string, "{val:x}").unwrap(),
         }
 
         serializer.serialize_str(string.as_str())

--- a/serde_at/src/ser/hex_str.rs
+++ b/serde_at/src/ser/hex_str.rs
@@ -1,7 +1,7 @@
 use crate::HexStr;
-use core::fmt::{Write};
-use core::ops::{ Deref };
+use core::fmt::Write;
 use core::fmt::{LowerHex, UpperHex};
+use core::ops::Deref;
 use serde::ser::Serialize;
 use serde::Serializer;
 
@@ -51,6 +51,5 @@ where
             }
             serializer.serialize_str(string.as_str())
         }
-
     }
 }

--- a/serde_at/src/ser/hex_str.rs
+++ b/serde_at/src/ser/hex_str.rs
@@ -37,7 +37,7 @@ where
                 string.push('x').unwrap();
             }
             for c in placeholder.chars().rev() {
-                string.push(c).unwrap()
+                string.push(c).unwrap();
             }
 
             serializer.serialize_str(string.as_str())

--- a/serde_at/src/ser/hex_str.rs
+++ b/serde_at/src/ser/hex_str.rs
@@ -1,6 +1,7 @@
 use crate::HexStr;
-use core::fmt::{LowerHex, UpperHex, Write};
-use core::ops::Deref;
+use core::fmt::{Write};
+use core::ops::{ Deref };
+use core::fmt::{LowerHex, UpperHex};
 use serde::ser::Serialize;
 use serde::Serializer;
 
@@ -13,15 +14,43 @@ where
     where
         S: Serializer,
     {
-        let mut string = heapless::String::<20>::new();
-        let val = **self;
-        match (self.add_0x_with_encoding, self.hex_in_caps) {
-            (true, true) => write!(string, "0x{val:X}").unwrap(),
-            (true, false) => write!(string, "0x{val:x}").unwrap(),
-            (false, true) => write!(string, "{val:X}").unwrap(),
-            (false, false) => write!(string, "{val:x}").unwrap(),
+        let val: <Self as Deref>::Target = **self;
+        if self.delimiter_after_nibble_count > 0 {
+            let mut string = heapless::String::<40>::new();
+            let mut placeholder = heapless::String::<40>::new();
+            if self.hex_in_caps {
+                write!(string, "{val:X}").unwrap();
+            } else {
+                write!(string, "{val:x}").unwrap();
+            }
+
+            for (index, c) in string.chars().rev().enumerate() {
+                if index != 0 && index % self.delimiter_after_nibble_count == 0 {
+                    placeholder.push(self.delimiter).unwrap();
+                }
+                placeholder.push(c).unwrap();
+            }
+
+            string.clear();
+            if self.add_0x_with_encoding {
+                string.push('0').unwrap();
+                string.push('x').unwrap();
+            }
+            for c in placeholder.chars().rev() {
+                string.push(c).unwrap()
+            }
+
+            serializer.serialize_str(string.as_str())
+        } else {
+            let mut string = heapless::String::<20>::new();
+            match (self.add_0x_with_encoding, self.hex_in_caps) {
+                (true, true) => write!(string, "0x{val:X}").unwrap(),
+                (true, false) => write!(string, "0x{val:x}").unwrap(),
+                (false, true) => write!(string, "{val:X}").unwrap(),
+                (false, false) => write!(string, "{val:x}").unwrap(),
+            }
+            serializer.serialize_str(string.as_str())
         }
 
-        serializer.serialize_str(string.as_str())
     }
 }

--- a/serde_at/src/ser/mod.rs
+++ b/serde_at/src/ser/mod.rs
@@ -551,6 +551,10 @@ mod tests {
             val_no_0x_caps: HexStr<u32>,
             val_0x_small_case: HexStr<u32>,
             val_no_0x_small_case: HexStr<u32>,
+            val_0x_caps_delimiter: HexStr<u32>,
+            val_no_0x_caps_delimiter: HexStr<u32>,
+            val_0x_small_case_delimiter: HexStr<u32>,
+            val_no_0x_small_case_delimiter: HexStr<u64>,
         }
 
         let params = WithHexStr {
@@ -558,25 +562,61 @@ mod tests {
                 val: 0xFF00,
                 hex_in_caps: true,
                 add_0x_with_encoding: true,
+                delimiter: ' ',
+                delimiter_after_nibble_count: 0
             },
             val_no_0x_caps: HexStr {
                 val: 0x55AA,
                 hex_in_caps: true,
                 add_0x_with_encoding: false,
+                delimiter: ' ',
+                delimiter_after_nibble_count: 0
             },
             val_0x_small_case: HexStr {
                 val: 0x00FF,
                 hex_in_caps: false,
                 add_0x_with_encoding: true,
+                delimiter: ' ',
+                delimiter_after_nibble_count: 0
             },
             val_no_0x_small_case: HexStr {
                 val: 0xAA55,
                 hex_in_caps: false,
                 add_0x_with_encoding: false,
+                delimiter: ' ',
+                delimiter_after_nibble_count: 0
+            },
+            val_0x_caps_delimiter: HexStr {
+                val: 0xFF00,
+                hex_in_caps: true,
+                add_0x_with_encoding: true,
+                delimiter: ':',
+                delimiter_after_nibble_count: 1
+            },
+            val_no_0x_caps_delimiter: HexStr {
+                val: 0x55AA,
+                hex_in_caps: true,
+                add_0x_with_encoding: false,
+                delimiter: '-',
+                delimiter_after_nibble_count: 2
+            },
+            val_0x_small_case_delimiter: HexStr {
+                val: 0x00FF,
+                hex_in_caps: false,
+                add_0x_with_encoding: true,
+                delimiter: ':',
+                delimiter_after_nibble_count: 1
+            },
+            val_no_0x_small_case_delimiter: HexStr {
+                val: 0xAA5500FF,
+                hex_in_caps: false,
+                add_0x_with_encoding: false,
+                delimiter: '-',
+                delimiter_after_nibble_count: 2
             },
         };
 
-        let s: String<100> = to_string(&params, "+CMD", SerializeOptions::default()).unwrap();
-        assert_eq!(s, String::<100>::from("AT+CMD=0xFF00,55AA,0xff,aa55\r\n"));
+        let s: String<200> = to_string(&params, "+CMD", SerializeOptions::default()).unwrap();
+        assert_eq!(s, String::<100>::from("AT+CMD=0xFF00,55AA,0xff,aa55,0xF:F:0:0,55-AA,0xf:f,aa-55-00-ff\r\n"));
     }
 }

--- a/serde_at/src/ser/mod.rs
+++ b/serde_at/src/ser/mod.rs
@@ -235,7 +235,7 @@ impl<'a, 'b, const B: usize> ser::Serializer for &'a mut Serializer<'b, B> {
 
     fn serialize_str(self, v: &str) -> Result<Self::Ok> {
         if self.options.quote_escape_strings {
-            self.buf.push(b'"')?
+            self.buf.push(b'"')?;
         }
         let mut encoding_tmp = [0_u8; 4];
         for c in v.chars() {

--- a/serde_at/src/ser/mod.rs
+++ b/serde_at/src/ser/mod.rs
@@ -563,60 +563,65 @@ mod tests {
                 hex_in_caps: true,
                 add_0x_with_encoding: true,
                 delimiter: ' ',
-                delimiter_after_nibble_count: 0
+                delimiter_after_nibble_count: 0,
             },
             val_no_0x_caps: HexStr {
                 val: 0x55AA,
                 hex_in_caps: true,
                 add_0x_with_encoding: false,
                 delimiter: ' ',
-                delimiter_after_nibble_count: 0
+                delimiter_after_nibble_count: 0,
             },
             val_0x_small_case: HexStr {
                 val: 0x00FF,
                 hex_in_caps: false,
                 add_0x_with_encoding: true,
                 delimiter: ' ',
-                delimiter_after_nibble_count: 0
+                delimiter_after_nibble_count: 0,
             },
             val_no_0x_small_case: HexStr {
                 val: 0xAA55,
                 hex_in_caps: false,
                 add_0x_with_encoding: false,
                 delimiter: ' ',
-                delimiter_after_nibble_count: 0
+                delimiter_after_nibble_count: 0,
             },
             val_0x_caps_delimiter: HexStr {
                 val: 0xFF00,
                 hex_in_caps: true,
                 add_0x_with_encoding: true,
                 delimiter: ':',
-                delimiter_after_nibble_count: 1
+                delimiter_after_nibble_count: 1,
             },
             val_no_0x_caps_delimiter: HexStr {
                 val: 0x55AA,
                 hex_in_caps: true,
                 add_0x_with_encoding: false,
                 delimiter: '-',
-                delimiter_after_nibble_count: 2
+                delimiter_after_nibble_count: 2,
             },
             val_0x_small_case_delimiter: HexStr {
                 val: 0x00FF,
                 hex_in_caps: false,
                 add_0x_with_encoding: true,
                 delimiter: ':',
-                delimiter_after_nibble_count: 1
+                delimiter_after_nibble_count: 1,
             },
             val_no_0x_small_case_delimiter: HexStr {
                 val: 0xAA5500FF,
                 hex_in_caps: false,
                 add_0x_with_encoding: false,
                 delimiter: '-',
-                delimiter_after_nibble_count: 2
+                delimiter_after_nibble_count: 2,
             },
         };
 
         let s: String<200> = to_string(&params, "+CMD", SerializeOptions::default()).unwrap();
-        assert_eq!(s, String::<100>::from("AT+CMD=0xFF00,55AA,0xff,aa55,0xF:F:0:0,55-AA,0xf:f,aa-55-00-ff\r\n"));
+        assert_eq!(
+            s,
+            String::<100>::from(
+                "AT+CMD=0xFF00,55AA,0xff,aa55,0xF:F:0:0,55-AA,0xf:f,aa-55-00-ff\r\n"
+            )
+        );
     }
 }

--- a/serde_at/src/ser/mod.rs
+++ b/serde_at/src/ser/mod.rs
@@ -243,7 +243,7 @@ impl<'a, 'b, const B: usize> ser::Serializer for &'a mut Serializer<'b, B> {
             self.buf.extend_from_slice(encoded.as_bytes())?;
         }
         if self.options.quote_escape_strings {
-            self.buf.push(b'"')?
+            self.buf.push(b'"')?;
         }
         Ok(())
     }

--- a/serde_at/src/ser/mod.rs
+++ b/serde_at/src/ser/mod.rs
@@ -8,6 +8,7 @@ use heapless::{String, Vec};
 
 mod enum_;
 mod struct_;
+mod hex_str;
 
 use self::enum_::{SerializeStructVariant, SerializeTupleVariant};
 use self::struct_::SerializeStruct;
@@ -83,20 +84,6 @@ impl<'a, const B: usize> Serializer<'a, B> {
             options,
         }
     }
-}
-
-/// Upper-case hex for value in 0..16, encoded as ASCII bytes
-fn hex_4bit(c: u8) -> u8 {
-    if c <= 9 {
-        0x30 + c
-    } else {
-        0x41 + (c - 10)
-    }
-}
-
-/// Upper-case hex for value in 0..256, encoded as ASCII bytes
-fn hex(c: u8) -> (u8, u8) {
-    (hex_4bit(c >> 4), hex_4bit(c & 0x0F))
 }
 
 // NOTE(serialize_*signed) This is basically the numtoa implementation minus the lookup tables,
@@ -235,74 +222,18 @@ impl<'a, 'b, const B: usize> ser::Serializer for &'a mut Serializer<'b, B> {
     }
 
     fn serialize_char(self, v: char) -> Result<Self::Ok> {
-        self.buf.push(b'"')?;
-        self.buf.push(v as u8)?;
-        self.buf.push(b'"')?;
+        let mut encoding_tmp = [0_u8; 4];
+        let encoded = v.encode_utf8(&mut encoding_tmp as &mut [u8]);
+        self.buf.extend_from_slice(encoded.as_bytes())?;
         Ok(())
     }
 
     fn serialize_str(self, v: &str) -> Result<Self::Ok> {
-        self.buf.push(b'"')?;
-
-        // Do escaping according to "6. MUST represent all strings (including object member names) in
-        // their minimal-length UTF-8 encoding": https://gibson042.github.io/canonicaljson-spec/
-        //
-        // We don't need to escape lone surrogates because surrogate pairs do not exist in valid UTF-8,
-        // even if they can exist in JSON or JavaScript strings (UCS-2 based). As a result, lone surrogates
-        // cannot exist in a Rust String. If they do, the bug is in the String constructor.
-        // An excellent explanation is available at https://www.youtube.com/watch?v=HhIEDWmQS3w
-
-        // Temporary storage for encoded a single char.
-        // A char is up to 4 bytes long wehn encoded to UTF-8.
         let mut encoding_tmp = [0_u8; 4];
-
         for c in v.chars() {
-            match c {
-                '\\' => {
-                    self.buf.push(b'\\')?;
-                    self.buf.push(b'\\')?;
-                }
-                '"' => {
-                    self.buf.push(b'\\')?;
-                    self.buf.push(b'"')?;
-                }
-                '\u{0008}' => {
-                    self.buf.push(b'\\')?;
-                    self.buf.push(b'b')?;
-                }
-                '\u{0009}' => {
-                    self.buf.push(b'\\')?;
-                    self.buf.push(b't')?;
-                }
-                '\u{000A}' => {
-                    self.buf.push(b'\\')?;
-                    self.buf.push(b'n')?;
-                }
-                '\u{000C}' => {
-                    self.buf.push(b'\\')?;
-                    self.buf.push(b'f')?;
-                }
-                '\u{000D}' => {
-                    self.buf.push(b'\\')?;
-                    self.buf.push(b'r')?;
-                }
-                '\u{0000}'..='\u{001F}' => {
-                    self.buf.push(b'\\')?;
-                    self.buf.push(b'u')?;
-                    self.buf.push(b'0')?;
-                    self.buf.push(b'0')?;
-                    let (hex1, hex2) = hex(c as u8);
-                    self.buf.push(hex1)?;
-                    self.buf.push(hex2)?;
-                }
-                _ => {
-                    let encoded = c.encode_utf8(&mut encoding_tmp as &mut [u8]);
-                    self.buf.extend_from_slice(encoded.as_bytes())?;
-                }
-            }
+            let encoded = c.encode_utf8(&mut encoding_tmp as &mut [u8]);
+            self.buf.extend_from_slice(encoded.as_bytes())?;
         }
-
-        self.buf.push(b'"')?;
         Ok(())
     }
 
@@ -532,6 +463,7 @@ mod tests {
     use heapless::String;
     use serde_bytes::Bytes;
     use serde_derive::{Deserialize, Serialize};
+    use crate::HexStr;
 
     #[derive(Clone, PartialEq, Serialize, Deserialize)]
     pub enum PacketSwitchedParam {
@@ -551,6 +483,7 @@ mod tests {
 
         QoSDelay3G(u32),
         CurrentProfileMap(u8),
+        AppEui(HexStr<u32>),
     }
 
     #[derive(Clone, PartialEq, Serialize, Deserialize)]
@@ -608,5 +541,42 @@ mod tests {
         };
         let s: String<32> = to_string(&b, "+CMD", SerializeOptions::default()).unwrap();
         assert_eq!(s, String::<32>::from("AT+CMD=Some bytes\r\n"));
+    }
+
+    #[test]
+    fn hex_str_serialize() {
+        #[derive(Clone, PartialEq, Serialize)]
+        pub struct WithHexStr {
+            val_0x_caps: HexStr<u32>,
+            val_no_0x_caps: HexStr<u32>,
+            val_0x_small_case: HexStr<u32>,
+            val_no_0x_small_case: HexStr<u32>
+        }
+
+        let params = WithHexStr {
+            val_0x_caps: HexStr {
+                val: 0xFF00,
+                hex_in_caps: true,
+                add_0x_with_encoding: true
+            },
+            val_no_0x_caps: HexStr {
+                val:0x55AA,
+                hex_in_caps: true,
+                add_0x_with_encoding: false
+            },
+            val_0x_small_case: HexStr {
+                val: 0x00FF,
+                hex_in_caps: false,
+                add_0x_with_encoding: true
+            },
+            val_no_0x_small_case: HexStr {
+                val: 0xAA55,
+                hex_in_caps: false,
+                add_0x_with_encoding: false
+            }
+        };
+
+        let s: String<100> = to_string(&params, "+CMD", SerializeOptions::default()).unwrap();
+        assert_eq!(s, String::<100>::from("AT+CMD=0xFF00,55AA,0xff,aa55\r\n"));
     }
 }

--- a/serde_at/src/ser/mod.rs
+++ b/serde_at/src/ser/mod.rs
@@ -34,7 +34,7 @@ pub struct SerializeOptions<'a> {
     /// Whether to add quotes before a string when serializing a string
     ///
     /// **default**: true
-    pub quote_escape_strings: bool
+    pub quote_escape_strings: bool,
 }
 
 impl<'a> Default for SerializeOptions<'a> {
@@ -43,7 +43,7 @@ impl<'a> Default for SerializeOptions<'a> {
             value_sep: true,
             cmd_prefix: "AT",
             termination: "\r\n",
-            quote_escape_strings: true
+            quote_escape_strings: true,
         }
     }
 }
@@ -628,7 +628,7 @@ mod tests {
         };
         let options = SerializeOptions {
             quote_escape_strings: false,
-            .. Default::default()
+            ..Default::default()
         };
         let s: String<200> = to_string(&params, "+CMD", options).unwrap();
         assert_eq!(

--- a/serde_at/src/ser/mod.rs
+++ b/serde_at/src/ser/mod.rs
@@ -7,8 +7,8 @@ use serde::ser;
 use heapless::{String, Vec};
 
 mod enum_;
-mod struct_;
 mod hex_str;
+mod struct_;
 
 use self::enum_::{SerializeStructVariant, SerializeTupleVariant};
 use self::struct_::SerializeStruct;
@@ -460,10 +460,10 @@ impl ser::SerializeTuple for Unreachable {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::HexStr;
     use heapless::String;
     use serde_bytes::Bytes;
     use serde_derive::{Deserialize, Serialize};
-    use crate::HexStr;
 
     #[derive(Clone, PartialEq, Serialize, Deserialize)]
     pub enum PacketSwitchedParam {
@@ -550,30 +550,30 @@ mod tests {
             val_0x_caps: HexStr<u32>,
             val_no_0x_caps: HexStr<u32>,
             val_0x_small_case: HexStr<u32>,
-            val_no_0x_small_case: HexStr<u32>
+            val_no_0x_small_case: HexStr<u32>,
         }
 
         let params = WithHexStr {
             val_0x_caps: HexStr {
                 val: 0xFF00,
                 hex_in_caps: true,
-                add_0x_with_encoding: true
+                add_0x_with_encoding: true,
             },
             val_no_0x_caps: HexStr {
-                val:0x55AA,
+                val: 0x55AA,
                 hex_in_caps: true,
-                add_0x_with_encoding: false
+                add_0x_with_encoding: false,
             },
             val_0x_small_case: HexStr {
                 val: 0x00FF,
                 hex_in_caps: false,
-                add_0x_with_encoding: true
+                add_0x_with_encoding: true,
             },
             val_no_0x_small_case: HexStr {
                 val: 0xAA55,
                 hex_in_caps: false,
-                add_0x_with_encoding: false
-            }
+                add_0x_with_encoding: false,
+            },
         };
 
         let s: String<100> = to_string(&params, "+CMD", SerializeOptions::default()).unwrap();


### PR DESCRIPTION
Allows 0xffff ffff 0XFFFF FFFF 0xff:ff ff-ff 0xFF:FF FF#FF to be serialized/deserialized.

Adds a struct HexStr<T> with its serialization / deserialization.

Note on the serialization of strings: 
My thinking is that we don't need the JSON escaping. Is the wrong?