### PR TITLE
Support URC's without a colon

### DIFF
--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -483,7 +483,7 @@ mod test {
         #[at_urc(b"+UMWI")]
         MessageWaitingIndication(MessageWaitingIndication),
         #[at_urc(b"CONNECT OK")]
-        ConnectOk
+        ConnectOk,
     }
 
     macro_rules! setup {

--- a/atat_derive/src/urc.rs
+++ b/atat_derive/src/urc.rs
@@ -64,16 +64,13 @@ pub fn atat_urc(input: TokenStream) -> TokenStream {
             #[inline]
             fn parse(resp: &[u8]) -> Option<Self::Response> {
                 // FIXME: this should be more generic than ':' (Split using #code?)
-                if let Some(index) = resp.iter().position(|&x| x == b':') {
-                    Some(match &resp[..index] {
-                        #(
-                            #match_arms
-                        )*
-                        _ => return None
-                    })
-                } else {
-                    None
-                }
+                let index = resp.iter().position(|&x| x == b':').unwrap_or(resp.len());
+                Some(match &resp[..index] {
+                    #(
+                        #match_arms
+                    )*
+                    _ => return None
+                })
             }
         }
 


### PR DESCRIPTION
The current implementation of the URC parser expects the format "code:" (including a colon). For the simcom sim800 modem there are URC's such as "CONNECT OK" without a colon. This PR lets the parser match on the entire response in case a colon is not found.