### PR TITLE
Fix digest continuation bug

### DIFF
--- a/atat/src/digest.rs
+++ b/atat/src/digest.rs
@@ -2,7 +2,7 @@ use core::marker::PhantomData;
 
 use crate::InternalError;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum DigestResult<'a> {
     Urc(&'a [u8]),
     Response(Result<&'a [u8], InternalError<'a>>),

--- a/atat/src/error/mod.rs
+++ b/atat/src/error/mod.rs
@@ -7,7 +7,7 @@ pub use cms_error::CmsError;
 pub use connection_error::ConnectionError;
 
 /// Errors returned used internally within the crate
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum InternalError<'a> {
     /// Serial read error
     Read,
@@ -147,7 +147,7 @@ impl<'a> From<&'a [u8]> for Response<'a> {
 }
 
 /// Errors returned by the crate
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     /// Serial read error

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -673,12 +673,12 @@ impl fmt::Display for Error {
 }
 
 fn trim_ascii_whitespace(x: &[u8]) -> &[u8] {
-    let from = match x.iter().position(|x| !x.is_ascii_whitespace()) {
-        Some(i) => i,
-        None => return &x[0..0],
-    };
-    let to = x.iter().rposition(|x| !x.is_ascii_whitespace()).unwrap();
-    &x[from..=to]
+    if let Some(from) = x.iter().position(|x| !x.is_ascii_whitespace()) {
+        let to = x.iter().rposition(|x| !x.is_ascii_whitespace()).unwrap();
+        &x[from..=to]
+    } else {
+        &x[0..0]
+    }
 }
 
 /// Deserializes an instance of type `T` from bytes of AT Response text

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -673,12 +673,13 @@ impl fmt::Display for Error {
 }
 
 fn trim_ascii_whitespace(x: &[u8]) -> &[u8] {
-    if let Some(from) = x.iter().position(|x| !x.is_ascii_whitespace()) {
-        let to = x.iter().rposition(|x| !x.is_ascii_whitespace()).unwrap();
-        &x[from..=to]
-    } else {
-        &x[0..0]
-    }
+    x.iter().position(|x| !x.is_ascii_whitespace()).map_or_else(
+        || &x[0..0],
+        |from| {
+            let to = x.iter().rposition(|x| !x.is_ascii_whitespace()).unwrap();
+            &x[from..=to]
+        },
+    )
 }
 
 /// Deserializes an instance of type `T` from bytes of AT Response text


### PR DESCRIPTION
The digest should not continue to lower priority cases if the parser returns incomplete.

This fixes #140