### PR TITLE
Avoid UB due to uninitialized memory in `serde_at`

### DIFF
--- a/serde_at/src/lib.rs
+++ b/serde_at/src/lib.rs
@@ -20,7 +20,19 @@ pub use self::de::{from_slice, from_str, hex_str::HexStr};
 #[doc(inline)]
 pub use self::ser::{to_string, to_vec, SerializeOptions};
 
-#[allow(clippy::uninit_assumed_init)]
-unsafe fn uninitialized<T>() -> T {
-    core::mem::MaybeUninit::uninit().assume_init()
+use core::mem::MaybeUninit;
+
+// TODO: Use `MaybeUninit::uninit_array` once it has stabilized?
+fn uninit_array<T, const N: usize>() -> [MaybeUninit<T>; N] {
+    // SAFETY: See `MaybeUninit::uninit_array`.
+    unsafe {
+        #[allow(clippy::uninit_assumed_init)]
+        MaybeUninit::uninit().assume_init()
+    }
+}
+
+// TODO: Use `MaybeUninit::slice_assume_init_ref` once it has stabilized?
+unsafe fn slice_assume_init_ref<T>(slice: &[MaybeUninit<T>]) -> &[T] {
+    // SAFETY: See `MaybeUninit::slice_assume_init_ref`.
+    unsafe { &*(slice as *const [MaybeUninit<T>] as *const [T]) }
 }


### PR DESCRIPTION
`mem::MaybeUninit::uninit().assume_init()` is almost always UB.
(Caught by Miri)