### PR TITLE
Ensure that any leading leftover space is trimmed in digester

### DIFF
--- a/atat/src/ingress.rs
+++ b/atat/src/ingress.rs
@@ -135,7 +135,7 @@ impl<
                 (DigestResult::None, swallowed) => {
                     if swallowed > 0 {
                         debug!(
-                            "Received echo or whitespace ({}/{}): {:?}",
+                            "Received echo or space ({}/{}): {:?}",
                             swallowed,
                             self.pos,
                             LossyStr(&self.buf[..self.pos])


### PR DESCRIPTION
The reason for this change is that e.g. the prompt which can be any of ">" or "> " (with space).
If the device uses "> " as prompt, and if we digest the partial prompt ">", then there will be a space in the ingress buffer for the next digest. This space should be trimmed.