### PR TITLE
Enable external client implementations by making response_channel pub

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
     // with these changes RA will call `cargo check --bins` on save
     "rust-analyzer.checkOnSave.allTargets": false,
     "rust-analyzer.cargo.target": "thumbv6m-none-eabi",
-    "rust-analyzer.cargo.features": ["async", "thumbv6"],
+    "rust-analyzer.cargo.features": ["async"],
     "rust-analyzer.diagnostics.disabled": [
         "unresolved-import"
     ]

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -232,7 +232,7 @@ mod ingress;
 mod response;
 pub mod response_channel;
 mod traits;
-mod urc_channel;
+pub mod urc_channel;
 pub use nom;
 
 pub mod blocking;

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -230,7 +230,7 @@ mod error;
 pub mod helpers;
 mod ingress;
 mod response;
-mod response_channel;
+pub mod response_channel;
 mod traits;
 mod urc_channel;
 pub use nom;


### PR DESCRIPTION
I want to use `atat` with an `rtic v2` project instead of embassy. Therefore I implemented my own async Client that does not depend on `embassy_time`. In order to have my own specific client implementation outside of the `atat` crate I need to access response_channel. So I have made it public. 

I feel like this is preferable over having many specific client implementations in `atat`.
