### PR TITLE
fix: Enable async_in_trait_feature

### DIFF
--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -217,7 +217,7 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::fallible_impl_from)]
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
-#![cfg_attr(feature = "async", allow(async_fn_in_trait))]
+#![cfg_attr(feature = "async", feature(async_fn_in_trait))]
 
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;


### PR DESCRIPTION
Could this possibly be a typo introduced in [this](https://github.com/BlackbirdHQ/atat/commit/27c12646944fb6560ff6aad9d02e87432757818b#diff-50caeb10f32ade2cbeb3b0d3e36cd113362c23991e99f816fb6c7b7fdde1275fR220) commit? It break compilation since the async feature was not enabled correctly.