### PR TITLE
expose currently internal error types

### DIFF
--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -264,7 +264,7 @@ pub use heapless;
 pub use buffers::Buffers;
 pub use config::Config;
 pub use digest::{AtDigester, AtDigester as DefaultDigester, DigestResult, Digester, Parser};
-pub use error::{Error, InternalError};
+pub use error::{CmeError, CmsError, ConnectionError, Error, InternalError};
 pub use ingress::{AtatIngress, Ingress};
 pub use response::Response;
 pub use response_channel::{ResponseChannel, ResponsePublisher, ResponseSubscription};


### PR DESCRIPTION
This exposes currently internal error types with are used inside the main error type and accessible to the user.
This is need for example when entering as PIN to modem and repeat the command on errors other then IncorrectPassword and/or SimPuk (I often have to deal with SIM cards that fail at first try on this command on my modem).
Fixes https://github.com/BlackbirdHQ/atat/issues/176
