### PR TITLE
Add LengthDelimited struct to parse <len, "bytes"> payloads.

### DIFF
--- a/serde_at/Cargo.toml
+++ b/serde_at/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.20.0"
 [dependencies]
 heapless = { version = "^0.8", features = ["serde"] }
 serde = { version = "^1", default-features = false }
+heapless-bytes = { version = "0.3.0" }
 
 [dependencies.num-traits]
 version = "0.2"
@@ -21,7 +22,6 @@ default-features = false
 
 [dev-dependencies]
 serde_derive = "^1"
-heapless-bytes = { version = "0.3.0" }
 serde_bytes = { version = "0.11.5", default-features = false }
 
 [features]

--- a/serde_at/src/de/length_delimited.rs
+++ b/serde_at/src/de/length_delimited.rs
@@ -1,0 +1,75 @@
+//! Parsing of length delimited byte strings.
+//!
+use core::fmt;
+
+use heapless_bytes::Bytes;
+use serde::{de, Deserialize, Deserializer};
+
+/// Structure for parsing a length delimited bytes payload.
+///
+/// This assumes that the payload is quoted.
+/// The quotes are in the byte stream but not counted in the length field.
+///
+/// For example:
+///
+/// From this response: `+QMTRECV: 1,0,"topic",4,"ABCD"`
+/// We can parse the last two parameters as a 'LengthDelimited' object:
+/// `'4,"ABCD"' => LengthDelimited { len: 4, bytes: [65, 66, 67, 68] }`
+///
+#[derive(Clone, Debug)]
+pub struct LengthDelimited<const N: usize> {
+    /// The number of bytes in the payload. This is actually
+    /// redundant since the `bytes` field also knows its own length.
+    pub len: usize,
+    /// The payload bytes
+    pub bytes: Bytes<N>,
+}
+
+impl<'de, const N: usize> Deserialize<'de> for LengthDelimited<N> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Ideally we use deserializer.deserialize_bytes but since it clips the payload
+        // at the first comma we cannot use it.
+        // Instead we use deserialize_tuple as it wasn't used yet.
+        deserializer.deserialize_tuple(2, LengthDelimitedVisitor::<N>) // The '2' is dummy.
+    }
+}
+struct LengthDelimitedVisitor<const N: usize>;
+
+impl<'de, const N: usize> de::Visitor<'de> for LengthDelimitedVisitor<N> {
+    type Value = LengthDelimited<N>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("length delimited bytes, e.g.: \"4,ABCD\"")
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        v.iter()
+            .position(|&c| c == b',')
+            .ok_or_else(|| de::Error::custom("expected a comma"))
+            .and_then(|pos| {
+                let len = parse_len(&v[0..pos])
+                    .map_err(|_| de::Error::custom("expected an unsigned int"))?;
+                // +1 to skip the comma after the length.
+                let start = pos + 1 + 1; // extra +1 to remove outer quotes
+                let end = start + len;
+                Ok(LengthDelimited {
+                    len,
+                    bytes: Bytes::from_slice(&v[start..end])
+                        .map_err(|_| de::Error::custom("incorrect slice size"))?,
+                })
+            })
+    }
+}
+
+/// Parses a slice of bytes into an unsigned integer.
+/// The slice must contain only ASCII _digits_ and must not contain additional bytes.
+fn parse_len(v: &[u8]) -> Result<usize, ()> {
+    let len_str: &str = core::str::from_utf8(v).map_err(|_| ())?;
+    len_str.parse().map_err(|_| ())
+}

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -919,6 +919,25 @@ mod tests {
     }
 
     #[test]
+    fn length_delimited_no_quotes() {
+        #[derive(Clone, Debug, Deserialize)]
+        pub struct PayloadResponse {
+            pub ctx: u8, // Some other params
+            pub id: i8,  // Some other params
+            pub payload: LengthDelimited<32>,
+        }
+
+        let res: PayloadResponse = crate::from_slice(b"1,-1,9,ABCD,1234").unwrap();
+        assert_eq!(res.ctx, 1);
+        assert_eq!(res.id, -1);
+        assert_eq!(res.payload.len, 9);
+        assert_eq!(
+            res.payload.bytes,
+            Bytes::<32>::from_slice(b"ABCD,1234").unwrap()
+        );
+    }
+
+    #[test]
     fn length_delimited_json() {
         #[derive(Clone, Debug, Deserialize)]
         pub struct PayloadResponse {
@@ -926,7 +945,6 @@ mod tests {
             pub id: i8,  // Some other params
             pub payload: LengthDelimited<32>,
         }
-        // This tests correct handling of commas in the payload.
         let res: PayloadResponse =
             crate::from_slice(b"1,-2,28,\"{\"cmd\": \"blink\", \"pin\": \"2\"}\"").unwrap();
         assert_eq!(res.ctx, 1);


### PR DESCRIPTION
This PR adds a struct to help parsing length delimited payloads. There are currently a few assumptions:

- The length delimited payload is at the end of a response. This is because I have not found a way to communicate back the number of eaten bytes used for parsing to the Deserializer.
- The payload is "quoted" but the quotes do not count for the length. This is how I have seen it on Quectel modems.

I still need to do more tests but I wouldn't mind some early feedback.

- I have commandeered `deserialize_tuple` as it was not used. I couldn't use `deserialize_bytes` as it clips the slice at the first `,`.
- In `deserialize_tuple` we set ` self.index = self.slice.len();` which causes `LengthDelimited` to only work at the end of the response.

