### PR TITLE
Publish bytes as Response if parsing URC fails.

### DIFF
--- a/atat/src/ingress.rs
+++ b/atat/src/ingress.rs
@@ -254,7 +254,11 @@ impl<
                             self.urc_publisher.publish(urc).await;
                         }
                     } else {
-                        error!("Parsing URC FAILED: {:?}", LossyStr(urc_line));
+                        warn!("Parsing URC FAILED: {:?}", LossyStr(urc_line));
+                        // Publish urc_line as a response
+                        if let Err(frame) = self.res_publisher.try_publish(Ok(urc_line).into()) {
+                            self.res_publisher.publish(frame).await;
+                        }
                     }
                     swallowed
                 }


### PR DESCRIPTION
This solves a conflict between URC and response tokens in the case that the struct definition is different.
