### PR TITLE
add support for deserialize_byte_buf when alloc is enabled

### DIFF
--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -516,12 +516,19 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             })
     }
 
-    /// Unsupported
+    /// Supported only if alloc feature is enabled
     fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        unreachable!()
+        #[cfg(feature = "alloc")]
+        {
+            self.deserialize_bytes(_visitor)
+        }
+        #[cfg(not(feature = "alloc"))]
+        {
+            unreachable!()
+        }
     }
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>


### PR DESCRIPTION
Now I hit unreachable!() on deserialize_byte_buf.
This PR adds support for deserialize_byte_buf when alloc feature is enabled.
Similar too https://github.com/BlackbirdHQ/atat/pull/192