### PR TITLE
Let Ingress take channel instead of publisher's and cleanup UrcChannel

### DIFF
--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -263,11 +263,11 @@ pub use heapless;
 pub use config::Config;
 pub use digest::{AtDigester, AtDigester as DefaultDigester, DigestResult, Digester, Parser};
 pub use error::{CmeError, CmsError, ConnectionError, Error, InternalError};
-pub use ingress::{AtatIngress, Ingress};
+pub use ingress::{AtatIngress, Error as IngressError, Ingress};
 pub use response::Response;
-pub use response_channel::{ResponseChannel, ResponsePublisher, ResponseSubscription};
+pub use response_channel::ResponseChannel;
 pub use traits::{AtatCmd, AtatResp, AtatUrc};
-pub use urc_channel::{AtatUrcChannel, UrcChannel, UrcSubscription};
+pub use urc_channel::{UrcChannel, UrcSubscription};
 
 #[cfg(test)]
 #[cfg(feature = "defmt")]

--- a/atat/src/urc_channel.rs
+++ b/atat/src/urc_channel.rs
@@ -14,13 +14,8 @@ pub enum Error {
     MaximumSubscribersReached,
 }
 
-pub trait AtatUrcChannel<Urc: AtatUrc, const CAPACITY: usize, const SUBSCRIBERS: usize> {
-    fn subscribe(&self) -> Result<UrcSubscription<'_, Urc, CAPACITY, SUBSCRIBERS>, Error>;
-    fn space(&self) -> usize;
-}
-
 pub struct UrcChannel<Urc: AtatUrc, const CAPACITY: usize, const SUBSCRIBERS: usize>(
-    PubSubChannel<CriticalSectionRawMutex, Urc::Response, CAPACITY, SUBSCRIBERS, 1>,
+    pub(crate) PubSubChannel<CriticalSectionRawMutex, Urc::Response, CAPACITY, SUBSCRIBERS, 1>,
 );
 
 impl<Urc: AtatUrc, const CAPACITY: usize, const SUBSCRIBERS: usize>
@@ -30,21 +25,13 @@ impl<Urc: AtatUrc, const CAPACITY: usize, const SUBSCRIBERS: usize>
         Self(PubSubChannel::new())
     }
 
-    pub fn publisher(&self) -> UrcPublisher<Urc, CAPACITY, SUBSCRIBERS> {
-        self.0.publisher().unwrap()
-    }
-}
-
-impl<Urc: AtatUrc, const CAPACITY: usize, const SUBSCRIBERS: usize>
-    AtatUrcChannel<Urc, CAPACITY, SUBSCRIBERS> for UrcChannel<Urc, CAPACITY, SUBSCRIBERS>
-{
-    fn subscribe(&self) -> Result<UrcSubscription<'_, Urc, CAPACITY, SUBSCRIBERS>, Error> {
+    pub fn subscribe(&self) -> Result<UrcSubscription<'_, Urc, CAPACITY, SUBSCRIBERS>, Error> {
         self.0
             .subscriber()
             .map_err(|_| Error::MaximumSubscribersReached)
     }
 
-    fn space(&self) -> usize {
+    pub fn space(&self) -> usize {
         self.0.space()
     }
 }

--- a/examples/src/bin/embassy.rs
+++ b/examples/src/bin/embassy.rs
@@ -51,11 +51,11 @@ async fn main(spawner: Spawner) {
     let (reader, writer) = uart.split();
 
     static RES_CHANNEL: ResponseChannel<INGRESS_BUF_SIZE> = ResponseChannel::new();
-    static URC_CHANNEL: UrcChannel<Urc, URC_CAPACITY, URC_SUBSCRIBERS> = UrcChannel::new();
+    static URC_CHANNEL: UrcChannel<common::Urc, URC_CAPACITY, URC_SUBSCRIBERS> = UrcChannel::new();
     let ingress = Ingress::new(
         DefaultDigester::<common::Urc>::default(),
-        RES_CHANNEL.publisher(),
-        URC_CHANNEL.publisher(),
+        &RES_CHANNEL,
+        &URC_CHANNEL,
     );
     let mut client = Client::new(writer, RES_CHANNEL.subscriber(), atat::Config::default());
 

--- a/examples/src/bin/std-tokio.rs
+++ b/examples/src/bin/std-tokio.rs
@@ -24,8 +24,8 @@ async fn main() -> ! {
     static URC_CHANNEL: UrcChannel<common::Urc, URC_CAPACITY, URC_SUBSCRIBERS> = UrcChannel::new();
     let ingress = Ingress::new(
         DefaultDigester::<common::Urc>::default(),
-        RES_CHANNEL.publisher().unwrap(),
-        URC_CHANNEL.publisher(),
+        &RES_CHANNEL,
+        &URC_CHANNEL,
     );
     let mut client = Client::new(FromTokio::new(writer), &RES_CHANNEL, Config::default());
 


### PR DESCRIPTION
This also removes the export of the ResponsePublisher/Subscriber as they are no longer needed. And, the AtatUrcChannel trait is removed. The methods are simply added to the UrcChannel struct