### PR TITLE
allow trailing characters to fit in the last field

### DIFF
--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -87,13 +87,6 @@ impl<'a> Deserializer<'a> {
         self.index += 1;
     }
 
-    fn end(&mut self) -> Result<()> {
-        match self.parse_whitespace() {
-            Some(_) => Err(Error::TrailingCharacters),
-            None => Ok(()),
-        }
-    }
-
     fn next_char(&mut self) -> Option<&u8> {
         if let Some(ch) = self.slice.get(self.index) {
             self.index += 1;
@@ -745,7 +738,6 @@ where
 {
     let mut de = Deserializer::new(trim_ascii_whitespace(v));
     let value = de::Deserialize::deserialize(&mut de)?;
-    de.end()?;
     Ok(value)
 }
 


### PR DESCRIPTION
With https://github.com/BlackbirdHQ/atat/pull/182 merged it is responsable to assume a response can have a leading , at it end. Example response:
```
+QIRD: 69\r\n\x01 @\x00\x00\x00\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0f\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x87,
```
I think it should be fine to completely remove this check for all cases, if that is not desired I can make it use the flag is_trailing_parsing had happen and then check if d.end() should be run. 