### PR TITLE
add custom parse function to AtatCmd derive

### DIFF
--- a/atat/src/derive.rs
+++ b/atat/src/derive.rs
@@ -302,4 +302,30 @@ mod tests {
             from_str::<MixedEnum<'_>>("6,\"abc\"")
         );
     }
+
+    fn custom_parse(response: &[u8]) -> Result<CustomResponseParse, atat::Error> {
+        Ok(CustomResponseParse {
+            arg1: core::str::from_utf8(&response[6..])
+                .unwrap()
+                .parse()
+                .unwrap(),
+        })
+    }
+
+    #[derive(Debug, PartialEq, AtatResp)]
+    struct CustomResponseParse {
+        arg1: u8,
+    }
+
+    #[derive(Debug, PartialEq, AtatCmd)]
+    #[at_cmd("+CFUN", CustomResponseParse, parse = custom_parse)]
+    struct RequestWithCustomResponseParse;
+
+    #[test]
+    fn test_custom_parse() {
+        assert_eq!(
+            RequestWithCustomResponseParse.parse(Ok(b"ignore123")),
+            Ok(CustomResponseParse { arg1: 123 })
+        );
+    }
 }

--- a/atat_derive/src/lib.rs
+++ b/atat_derive/src/lib.rs
@@ -154,6 +154,9 @@ pub fn derive_atat_enum(input: TokenStream) -> TokenStream {
 /// - `termination`: **string** Overwrite the line termination of the command
 ///   (default '\r\n'). Can also be set to '' (empty).
 /// - `quote_escape_strings`: **bool** Whether to escape strings in commands (default true).
+/// - `parse`: **function** Function that should be used to parse the response instead of using
+///    default `atat::serde_at::from_slice` function. The passed functions needs to have a signature
+///    `Result<Response, E>` where `Response` is the type of the response passed in the `at_cmd`
 ///
 /// ### Field attribute (`#[at_arg(..)]`)
 /// The `AtatCmd` derive macro comes with an optional field attribute


### PR DESCRIPTION
While still struggling with parsing QIRD response from Quactel BG95 for all possible use case where the binary payload does contain bytes that are equal too \n or \r or other whitespace or even comma with was causing a lot of problems too I come to the conclusion that the response is just to obscure for serde_at and I implemented `AtatCmd` trait myself overriding the parse function to not use serde_at at all for this one outlier. 

But that does lead to a lot more boilerplate in my code since now I need to implement `AtatLen` and all other trait functions for that structs. With this PR this can be avoided and a user can just provide a custom parse function with the parse argument on the `at_cmd` attributes when using `AtatCmd` derive