### PR TITLE
Do not recognize CONNECT <NUM> as a success response.

### DIFF
--- a/atat/src/digest.rs
+++ b/atat/src/digest.rs
@@ -328,8 +328,8 @@ pub mod parser {
                 nom::combinator::success(&b""[..]),
             )),
             tuple((
-                take_until_including("\r\nCONNECT"),
-                recognize(take_until_including("\r\n")),
+                take_until_including("\r\nCONNECT\r\n"),
+                nom::combinator::success(&b""[..]),
             )),
         ))(buf)?;
 


### PR DESCRIPTION
This is required for AT commands where the modem responds with

`CONNECT <NUM>` followed by `NUM` bytes.

The tests still work so I am not sure if there was a specific reason for 

```rust
 take_until_including("\r\nCONNECT"),
 recognize(take_until_including("\r\n")),
```

vs

```rust
 take_until_including("\r\nCONNECT\r\n"),
```

Do we in some cases expect bytes between `CONNECT` and `\r\n` that we want to discard?