### PR TITLE
feature(*): Add option for custom parse fn in AtatUrc

### DIFF
--- a/atat/src/digest.rs
+++ b/atat/src/digest.rs
@@ -10,6 +10,7 @@ pub enum DigestResult<'a> {
     None,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ParseError {
     Incomplete,
     NoMatch,
@@ -351,7 +352,7 @@ pub mod parser {
         recognize(nom::bytes::complete::take_until("\r\n"))(buf)
     }
 
-    fn take_until_including<T, Input, Error: ParseError<Input>>(
+    pub fn take_until_including<T, Input, Error: ParseError<Input>>(
         tag: T,
     ) -> impl Fn(Input) -> IResult<Input, (Input, Input), Error>
     where

--- a/atat_derive/src/lib.rs
+++ b/atat_derive/src/lib.rs
@@ -60,6 +60,18 @@ pub fn derive_atat_resp(input: TokenStream) -> TokenStream {
 /// Automatically derive [`atat::AtatUrc`] trait
 ///
 /// [`atat::AtatUrc`]: ../atat/trait.AtatUrc.html
+///
+/// ### Field attribute (`#[at_urc(..)]`)
+/// The `AtatUrc` derive macro comes with a required field attribute
+/// `#[at_urc(..)]`, that is used to specify the URC token to match for.
+///
+/// The first argument is required, and must be either a string or a byte
+/// literal, specifying the URC token to match for.
+///
+/// Allowed optionals for `at_urc` are:
+/// - `parse`: **function** Function that should be used to parse for the URC
+///    instead of using default `atat::digest::parser::urc_helper` function. The
+///    passed functions needs to have a valid non signature.
 #[proc_macro_derive(AtatUrc, attributes(at_urc))]
 pub fn derive_atat_urc(input: TokenStream) -> TokenStream {
     urc::atat_urc(input)
@@ -77,10 +89,11 @@ pub fn derive_atat_urc(input: TokenStream) -> TokenStream {
 /// Furthermore it automatically implements [`atat::AtatLen`], based on the data
 /// type given in the container attribute.
 ///
-/// **NOTE**: When using this derive macro with struct or tuple variants in the enum, one
-/// should take extra care to avoid large size variations of the variants, as the
-/// resulting `AtatLen` of the enum will be the length of the representation
-/// (see `#[at_enum(..)]`) together with the largest sum of field values in the variant.
+/// **NOTE**: When using this derive macro with struct or tuple variants in the
+/// enum, one should take extra care to avoid large size variations of the
+/// variants, as the resulting `AtatLen` of the enum will be the length of the
+/// representation (see `#[at_enum(..)]`) together with the largest sum of field
+/// values in the variant.
 ///
 /// Eg.
 /// ```ignore
@@ -102,8 +115,8 @@ pub fn derive_atat_urc(input: TokenStream) -> TokenStream {
 /// `LargeSizeVariations::VariantOne`
 ///
 /// ### Container attribute (`#[at_enum(..)]`)
-/// The `AtatEnum` derive macro comes with an option of annotating the struct with
-/// a container attribute `#[at_enum(..)]`.
+/// The `AtatEnum` derive macro comes with an option of annotating the struct
+/// with a container attribute `#[at_enum(..)]`.
 ///
 /// The container attribute only allows specifying a single parameter, that is
 /// non-optional if the container attribute is present. The parameter allows
@@ -116,10 +129,10 @@ pub fn derive_atat_urc(input: TokenStream) -> TokenStream {
 ///
 /// ### Field attribute (`#[at_arg(..)]`)
 /// The `AtatEnum` derive macro comes with an optional field attribute
-/// `#[at_arg(..)]`, that can be specified o some or all of the fields.
+/// `#[at_arg(..)]`, that can be specified for some or all of the fields.
 ///
 /// Allowed options for `at_arg` are:
-/// - `value` **integer** The value of the serialized field
+/// - `value`: **integer** The value of the serialized field
 #[proc_macro_derive(AtatEnum, attributes(at_enum, at_arg))]
 pub fn derive_atat_enum(input: TokenStream) -> TokenStream {
     enum_::atat_enum(input)
@@ -153,10 +166,12 @@ pub fn derive_atat_enum(input: TokenStream) -> TokenStream {
 ///   'AT'). Can also be set to '' (empty).
 /// - `termination`: **string** Overwrite the line termination of the command
 ///   (default '\r\n'). Can also be set to '' (empty).
-/// - `quote_escape_strings`: **bool** Whether to escape strings in commands (default true).
-/// - `parse`: **function** Function that should be used to parse the response instead of using
-///    default `atat::serde_at::from_slice` function. The passed functions needs to have a signature
-///    `Result<Response, E>` where `Response` is the type of the response passed in the `at_cmd`
+/// - `quote_escape_strings`: **bool** Whether to escape strings in commands
+///   (default true).
+/// - `parse`: **function** Function that should be used to parse the response
+///    instead of using default `atat::serde_at::from_slice` function. The
+///    passed functions needs to have a signature `Result<Response, E>` where
+///    `Response` is the type of the response passed in the `at_cmd`
 ///
 /// ### Field attribute (`#[at_arg(..)]`)
 /// The `AtatCmd` derive macro comes with an optional field attribute

--- a/atat_derive/src/urc.rs
+++ b/atat_derive/src/urc.rs
@@ -19,7 +19,8 @@ pub fn atat_urc(input: TokenStream) -> TokenStream {
 
     let (match_arms, digest_arms): (Vec<_>, Vec<_>) = variants.iter().map(|variant| {
         let UrcAttributes {
-            code
+            code,
+            parse
         } = variant.attrs.at_urc.clone().unwrap_or_else(|| {
             panic!(
                 "missing #[at_urc(...)] attribute",
@@ -49,8 +50,14 @@ pub fn atat_urc(input: TokenStream) -> TokenStream {
             }
         };
 
-        let digest_arm = quote! {
-            atat::digest::parser::urc_helper(&#code[..]),
+        let digest_arm = if let Some(parse_fn) = parse {
+            quote! {
+                #parse_fn(&#code[..]),
+            }
+        } else {
+            quote! {
+                atat::digest::parser::urc_helper(&#code[..]),
+            }
         };
 
         (parse_arm, digest_arm)

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -778,6 +778,14 @@ mod tests {
         p3: Option<bool>,
     }
 
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct OptionEmpty {
+        p1: u8,
+        p2: i16,
+        p3: Option<bool>,
+        p4: bool,
+    }
+
     #[derive(Clone, Debug, Deserialize, PartialEq)]
     pub struct CCID {
         pub ccid: u128,
@@ -809,6 +817,16 @@ mod tests {
                 p1: 2,
                 p2: 56,
                 p3: None
+            })
+        );
+
+        assert_eq!(
+            crate::from_str("+CFG: 2,56,,true"),
+            Ok(OptionEmpty {
+                p1: 2,
+                p2: 56,
+                p3: None,
+                p4: true
             })
         );
 


### PR DESCRIPTION
Add an optional parse fn to the at_urc field attribute of AtatUrc, that allows specifying a custom nom function to be used during digest. This allows doing stricter checks for cases where responses are hard to distinguish from URCs.

Fixes https://github.com/BlackbirdHQ/atat/issues/179 (See example of a stricter custom CxREG parser fn in tests (`fn custom_cxreg_parse`))

