### PR TITLE
remove <LF> from the default command terminator

### DIFF
--- a/atat/src/blocking/client.rs
+++ b/atat/src/blocking/client.rs
@@ -341,8 +341,8 @@ mod test {
         .unwrap();
 
         let (sent0, sent1) = sent.await.unwrap();
-        assert_eq!("AT+CFUN=4,0\r\n", &sent0);
-        assert_eq!("AT+FUN=1,6\r\n", &sent1);
+        assert_eq!("AT+CFUN=4,0\r", &sent0);
+        assert_eq!("AT+FUN=1,6\r", &sent1);
     }
 
     #[tokio::test]
@@ -367,7 +367,7 @@ mod test {
         .unwrap();
 
         let sent = sent.await.unwrap();
-        assert_eq!("AT+CFUN=4,0\r\n", &sent);
+        assert_eq!("AT+CFUN=4,0\r", &sent);
     }
 
     // Test response containing string

--- a/atat/src/derive.rs
+++ b/atat/src/derive.rs
@@ -218,7 +218,7 @@ mod tests {
         .write(&mut buf);
         assert_eq!(
             &buf[..len],
-            Vec::<u8, 360>::from_slice(b"AT+CFUN=8,\"SomeString\",2,\"whatup\",0,0,1\r\n").unwrap()
+            Vec::<u8, 360>::from_slice(b"AT+CFUN=8,\"SomeString\",2,\"whatup\",0,0,1\r").unwrap()
         );
     }
 

--- a/atat_derive/src/lib.rs
+++ b/atat_derive/src/lib.rs
@@ -19,7 +19,7 @@
 //! [`AtatCmd`]: derive.AtatCmd.html
 //!
 //! ```ignore
-//! // Serializing the following struct, results in `AT+USORD=<socket>,<length>\r\n`
+//! // Serializing the following struct, results in `AT+USORD=<socket>,<length>\r`
 //! #[derive(AtatCmd)]
 //! #[at_cmd("+USORD", SocketData)]
 //! pub struct ReadSocketData {
@@ -165,7 +165,7 @@ pub fn derive_atat_enum(input: TokenStream) -> TokenStream {
 /// - `cmd_prefix`: **string** Overwrite the prefix of the command (default
 ///   'AT'). Can also be set to '' (empty).
 /// - `termination`: **string** Overwrite the line termination of the command
-///   (default '\r\n'). Can also be set to '' (empty).
+///   (default '\r'). Can also be set to '' (empty).
 /// - `quote_escape_strings`: **bool** Whether to escape strings in commands
 ///   (default true).
 /// - `parse`: **function** Function that should be used to parse the response

--- a/atat_derive/src/parse.rs
+++ b/atat_derive/src/parse.rs
@@ -274,7 +274,7 @@ impl Parse for CmdAttributes {
             response_code: None,
             value_sep: true,
             cmd_prefix: String::from("AT"),
-            termination: String::from("\r\n"),
+            termination: String::from("\r"),
             quote_escape_strings: true,
         };
 

--- a/serde_at/src/ser/mod.rs
+++ b/serde_at/src/ser/mod.rs
@@ -41,7 +41,7 @@ impl<'a> Default for SerializeOptions<'a> {
         SerializeOptions {
             value_sep: true,
             cmd_prefix: "AT",
-            termination: "\r\n",
+            termination: "\r",
             quote_escape_strings: true,
         }
     }
@@ -639,7 +639,7 @@ mod tests {
 
         let s: String<32> = to_string(&value, "+CMD", SerializeOptions::default()).unwrap();
 
-        assert_eq!(s, String::<32>::try_from("AT+CMD\r\n").unwrap());
+        assert_eq!(s, String::<32>::try_from("AT+CMD\r").unwrap());
     }
 
     #[test]
@@ -653,7 +653,7 @@ mod tests {
 
         let s: String<32> = to_string(&value, "+CMD", SerializeOptions::default()).unwrap();
 
-        assert_eq!(s, String::<32>::try_from("AT+CMD=\"value\"\r\n").unwrap());
+        assert_eq!(s, String::<32>::try_from("AT+CMD=\"value\"\r").unwrap());
     }
 
     #[test]
@@ -667,7 +667,7 @@ mod tests {
             s: Bytes::new(&slice[..]),
         };
         let s: String<32> = to_string(&b, "+CMD", SerializeOptions::default()).unwrap();
-        assert_eq!(s, String::<32>::try_from("AT+CMD=Some bytes\r\n").unwrap());
+        assert_eq!(s, String::<32>::try_from("AT+CMD=Some bytes\r").unwrap());
     }
 
     #[test]
@@ -688,7 +688,7 @@ mod tests {
 
         let s: String<32> = to_string(&value, "+CMD", SerializeOptions::default()).unwrap();
 
-        assert_eq!(s, String::<32>::try_from("AT+CMD=\"value\"\r\n").unwrap());
+        assert_eq!(s, String::<32>::try_from("AT+CMD=\"value\"\r").unwrap());
     }
 
     #[test]
@@ -706,7 +706,7 @@ mod tests {
 
         let s: String<32> = to_string(&value, "+CMD", SerializeOptions::default()).unwrap();
 
-        assert_eq!(s, String::<32>::try_from("AT+CMD=1.23,4.56\r\n").unwrap());
+        assert_eq!(s, String::<32>::try_from("AT+CMD=1.23,4.56\r").unwrap());
     }
 
     #[test]
@@ -797,7 +797,7 @@ mod tests {
         assert_eq!(
             s,
             String::<600>::try_from(
-                "AT+CMD=0x0000FF00,000055AA,0x000000ff,0000aa55,0x0:0:0:0:F:F:0:0,00-00-55-AA,0x0:0:0:0:0:0:f:f,00-00-00-00-aa-55-00-ff\r\n"
+                "AT+CMD=0x0000FF00,000055AA,0x000000ff,0000aa55,0x0:0:0:0:F:F:0:0,00-00-55-AA,0x0:0:0:0:0:0:f:f,00-00-00-00-aa-55-00-ff\r"
             ).unwrap()
         );
 
@@ -875,7 +875,7 @@ mod tests {
         assert_eq!(
             s,
             String::<600>::try_from(
-                "AT+CMD=0xFF00,55AA,0xff,aa55,0xF:F:0:0,55-AA,0xf:f,aa-55-00-ff\r\n"
+                "AT+CMD=0xFF00,55AA,0xff,aa55,0xF:F:0:0,55-AA,0xf:f,aa-55-00-ff\r"
             )
             .unwrap()
         );


### PR DESCRIPTION
Change the default AT command terminator to `<CR>` , instead of `<CR><LF>` .
See #215 for discussion.