### PR TITLE
Support more vendors' extended command syntax

### DIFF
--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -190,7 +190,7 @@ impl<'a> Deserializer<'a> {
     }
 
     fn parse_at(&mut self) -> Result<Option<()>> {
-        // If we find a '+', check if it is an AT command identifier, ending in ':'
+        // match AT command identifier starting in known prefixes and ending in ':'
         if self.parse_whitespace().map(|c| match c {
             b'+' | b'#' | b'$' | b'&' | b'%' => true,
             _ => false,


### PR DESCRIPTION
Simple workaround for the situation in #247 while keeping the response handling still naïve to the original command.

fixes #247 