### PR TITLE
Fix `defmt` feature

### DIFF
--- a/atat/Cargo.toml
+++ b/atat/Cargo.toml
@@ -48,7 +48,7 @@ static_cell = { version = "2.0.0" }
 
 [features]
 default = ["derive", "bytes"]
-defmt = ["dep:defmt", "embedded-io-async/defmt", "heapless/defmt"]
+defmt = ["dep:defmt", "embedded-io-async/defmt", "heapless/defmt", "serde_at/defmt", "embassy-time/defmt"]
 derive = ["atat_derive", "serde_at"]
 bytes = ["heapless-bytes", "serde_bytes"]
 custom-error-messages = []

--- a/atat/src/asynch/client.rs
+++ b/atat/src/asynch/client.rs
@@ -181,6 +181,7 @@ mod tests {
     }
 
     #[derive(Clone, AtatResp, PartialEq, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct NoResponse;
 
     macro_rules! setup {

--- a/atat/src/blocking/client.rs
+++ b/atat/src/blocking/client.rs
@@ -214,9 +214,11 @@ mod test {
         Reset,
     }
     #[derive(Clone, AtatResp, PartialEq, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct NoResponse;
 
     #[derive(Clone, AtatResp, PartialEq, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct TestResponseString {
         #[at_arg(position = 0)]
         pub socket: u8,
@@ -227,6 +229,7 @@ mod test {
     }
 
     #[derive(Clone, AtatResp, PartialEq, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct TestResponseStringMixed {
         #[at_arg(position = 1)]
         pub socket: u8,

--- a/atat/src/derive.rs
+++ b/atat/src/derive.rs
@@ -135,6 +135,7 @@ mod tests {
     struct NoResponse {}
 
     #[derive(Debug, PartialEq, AtatEnum)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     enum SimpleEnum {
         #[at_arg(default, value = 0)]
         A,
@@ -146,6 +147,7 @@ mod tests {
         D,
     }
     #[derive(Debug, PartialEq, AtatEnum)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     #[at_enum(u32)]
     enum SimpleEnumU32 {
         #[at_arg(default)]
@@ -156,6 +158,7 @@ mod tests {
     }
 
     #[derive(Debug, PartialEq, AtatEnum)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     enum MixedEnum<'a> {
         #[at_arg(value = 0)]
         UnitVariant,
@@ -387,6 +390,7 @@ mod tests {
     }
 
     #[derive(Debug, PartialEq, AtatResp)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     struct CustomResponseParse {
         arg1: u8,
     }

--- a/atat/src/digest.rs
+++ b/atat/src/digest.rs
@@ -3,6 +3,7 @@ use core::marker::PhantomData;
 use crate::InternalError;
 
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DigestResult<'a> {
     Urc(&'a [u8]),
     Response(Result<&'a [u8], InternalError<'a>>),

--- a/atat/src/ingress.rs
+++ b/atat/src/ingress.rs
@@ -333,6 +333,7 @@ mod tests {
     use super::*;
 
     #[derive(AtatUrc, Clone, PartialEq, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     enum Urc {
         #[at_urc(b"CONNECT OK")]
         ConnectOk,

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -279,20 +279,17 @@ mod tests {
     //! This module is required in order to satisfy the requirements of defmt, while running tests.
     //! Note that this will cause all log `defmt::` log statements to be thrown away.
 
-    use core::ptr::NonNull;
-
     #[defmt::global_logger]
     struct Logger;
-    impl defmt::Write for Logger {
-        fn write(&mut self, _bytes: &[u8]) {}
-    }
 
     unsafe impl defmt::Logger for Logger {
-        fn acquire() -> Option<NonNull<dyn defmt::Write>> {
-            Some(NonNull::from(&Logger as &dyn defmt::Write))
-        }
+        fn acquire() {}
 
-        unsafe fn release(_: NonNull<dyn defmt::Write>) {}
+        unsafe fn flush() {}
+
+        unsafe fn release() {}
+
+        unsafe fn write(_bytes: &[u8]) {}
     }
 
     defmt::timestamp!("");

--- a/atat/src/response.rs
+++ b/atat/src/response.rs
@@ -2,6 +2,7 @@ use crate::InternalError;
 use heapless::Vec;
 
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Response<const N: usize> {
     Ok(Vec<u8, N>),
     Prompt(u8),

--- a/atat/src/traits.rs
+++ b/atat/src/traits.rs
@@ -123,6 +123,7 @@ mod test {
     use heapless::String;
 
     #[derive(Debug, Clone, PartialEq, AtatEnum)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum PDPContextStatus {
         /// 0: deactivated
         Deactivated = 0,
@@ -131,6 +132,7 @@ mod test {
     }
 
     #[derive(Debug, Clone, AtatResp, PartialEq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct PDPContextState {
         #[at_arg(position = 0)]
         pub cid: u8,
@@ -139,6 +141,7 @@ mod test {
     }
 
     #[derive(Debug, Clone, AtatResp, PartialEq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct PDPContextDefinition {
         #[at_arg(position = 0)]
         pub cid: u8,

--- a/atat/src/tx_mock.rs
+++ b/atat/src/tx_mock.rs
@@ -1,4 +1,3 @@
-use core::fmt;
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, pubsub::Publisher};
 use embedded_io::ErrorType;
 use heapless::String;

--- a/serde_at/Cargo.toml
+++ b/serde_at/Cargo.toml
@@ -16,6 +16,7 @@ heapless = { workspace = true, features = ["serde"], optional = true }
 serde = { version = "^1", default-features = false }
 heapless-bytes = { workspace = true, optional = true }
 log = { version = "0.4", default-features = false, optional = true }
+defmt = { version = "^1.0.1", optional = true }
 
 [dependencies.num-traits]
 version = "0.2"
@@ -32,3 +33,4 @@ std = ["alloc"]
 hex_str_arrays = []
 alloc = ["serde/alloc"]
 heapless = ["dep:heapless", "dep:heapless-bytes"]
+defmt = ["dep:defmt"]

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -26,6 +26,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 
 /// This type represents all possible errors that can occur when deserializing AT Command strings
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum Error {
     /// EOF while parsing an object.


### PR DESCRIPTION
A lot of types where missing the conditional derive for the `defmt::Format` trait.
Tests were failing and on some public types (e.g. `DigestResult`) the problem was visible by dependants.