### PR TITLE
Remove `RefCell` from `ResponseSlot`

### DIFF
--- a/atat/src/asynch/client.rs
+++ b/atat/src/asynch/client.rs
@@ -2,7 +2,7 @@ use super::AtatClient;
 use crate::{
     helpers::LossyStr,
     response_slot::{ResponseSlot, ResponseSlotGuard},
-    AtatCmd, Config, Error, Response,
+    AtatCmd, Config, Error,
 };
 use embassy_time::{with_timeout, Duration, Instant, TimeoutError, Timer};
 use embedded_io::ErrorType;
@@ -127,8 +127,7 @@ impl<W: Write, const INGRESS_BUF_SIZE: usize> AtatClient for Client<'_, W, INGRE
             let response = self
                 .wait_response(Duration::from_millis(Cmd::MAX_TIMEOUT_MS.into()))
                 .await?;
-            let response: &Response<INGRESS_BUF_SIZE> = &response.borrow();
-            cmd.parse(response.into())
+            cmd.parse((&*response).into())
         }
     }
 }

--- a/atat/src/blocking/client.rs
+++ b/atat/src/blocking/client.rs
@@ -5,7 +5,7 @@ use super::{blocking_timer::BlockingTimer, AtatClient};
 use crate::{
     helpers::LossyStr,
     response_slot::{ResponseSlot, ResponseSlotGuard},
-    AtatCmd, Config, Error, Response,
+    AtatCmd, Config, Error,
 };
 
 /// Client responsible for handling send, receive and timeout from the
@@ -112,8 +112,7 @@ where
             cmd.parse(Ok(&[]))
         } else {
             let response = self.wait_response(Duration::from_millis(Cmd::MAX_TIMEOUT_MS.into()))?;
-            let response: &Response<INGRESS_BUF_SIZE> = &response.borrow();
-            cmd.parse(response.into())
+            cmd.parse((&*response).into())
         }
     }
 }

--- a/atat/src/ingress.rs
+++ b/atat/src/ingress.rs
@@ -471,8 +471,7 @@ mod tests {
         assert_eq!(Urc::CustomParse, sub.try_next_message_pure().unwrap());
 
         let response = res_slot.try_get().unwrap();
-        let response: &Response<100> = &response.borrow();
-        assert_eq!(&Response::default(), response);
+        assert_eq!(Response::default(), *response);
     }
 
     #[tokio::test]

--- a/atat/src/response_slot.rs
+++ b/atat/src/response_slot.rs
@@ -1,4 +1,3 @@
-use core::cell::RefCell;
 use embassy_sync::{
     blocking_mutex::raw::CriticalSectionRawMutex,
     mutex::{Mutex, MutexGuard},
@@ -9,12 +8,12 @@ use heapless::Vec;
 use crate::{InternalError, Response};
 
 pub struct ResponseSlot<const N: usize>(
-    Mutex<CriticalSectionRawMutex, RefCell<Response<N>>>,
+    Mutex<CriticalSectionRawMutex, Response<N>>,
     Signal<CriticalSectionRawMutex, ()>,
 );
 
 pub type ResponseSlotGuard<'a, const N: usize> =
-    MutexGuard<'a, CriticalSectionRawMutex, RefCell<Response<N>>>;
+    MutexGuard<'a, CriticalSectionRawMutex, Response<N>>;
 
 #[derive(Debug)]
 pub struct SlotInUseError;
@@ -27,10 +26,7 @@ impl<const N: usize> Default for ResponseSlot<N> {
 
 impl<const N: usize> ResponseSlot<N> {
     pub const fn new() -> Self {
-        Self(
-            Mutex::new(RefCell::new(Response::Ok(Vec::new()))),
-            Signal::new(),
-        )
+        Self(Mutex::new(Response::Ok(Vec::new())), Signal::new())
     }
 
     /// Reset the current response slot
@@ -62,11 +58,7 @@ impl<const N: usize> ResponseSlot<N> {
         }
 
         // Not currently signaled: We know that the client is not currently holding the response slot guard
-        {
-            let buf = self.0.try_lock().unwrap();
-            let mut res = buf.borrow_mut();
-            *res = Response::Prompt(prompt);
-        }
+        *self.0.try_lock().unwrap() = Response::Prompt(prompt);
 
         // Mutex is unlocked before we signal
         self.1.signal(());
@@ -82,11 +74,7 @@ impl<const N: usize> ResponseSlot<N> {
         }
 
         // Not currently signaled: We know that the client is not currently holding the response slot guard
-        {
-            let buf = self.0.try_lock().unwrap();
-            let mut res = buf.borrow_mut();
-            *res = response.into();
-        }
+        *self.0.try_lock().unwrap() = response.into();
 
         // Mutex is unlocked before we signal
         self.1.signal(());


### PR DESCRIPTION
I don't find any use in having it.

Correct me if I'm wrong.