### PR TITLE
Replace trim_ascii_whitespace with [u8]::trim_ascii

### DIFF
--- a/atat/src/digest.rs
+++ b/atat/src/digest.rs
@@ -238,10 +238,7 @@ pub mod parser {
                 ))),
             ))(i)?;
 
-            Ok((
-                i,
-                (trim_ascii_whitespace(urc_tag), le.len() + urc_tag.len()),
-            ))
+            Ok((i, (urc_tag.trim_ascii(), le.len() + urc_tag.len())))
         }
     }
 
@@ -349,7 +346,7 @@ pub mod parser {
         Ok((
             i,
             (
-                DigestResult::Response(Ok(trim_ascii_whitespace(data))),
+                DigestResult::Response(Ok(data.trim_ascii())),
                 data.len() + tag.len() + ws.len(),
             ),
         ))
@@ -426,10 +423,7 @@ pub mod parser {
 
             Ok((
                 i,
-                (
-                    trim_ascii_whitespace(error_msg),
-                    prefix_data.len() + error_msg.len(),
-                ),
+                (error_msg.trim_ascii(), prefix_data.len() + error_msg.len()),
             ))
         }
     }
@@ -476,15 +470,6 @@ pub mod parser {
                 ),
             ))(i)
         }
-    }
-
-    fn trim_ascii_whitespace(x: &[u8]) -> &[u8] {
-        let from = match x.iter().position(|x| !x.is_ascii_whitespace()) {
-            Some(i) => i,
-            None => return &x[0..0],
-        };
-        let to = x.iter().rposition(|x| !x.is_ascii_whitespace()).unwrap();
-        &x[from..=to]
     }
 
     pub fn trim_start_ascii_space(x: &[u8]) -> &[u8] {

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -725,16 +725,6 @@ impl fmt::Display for Error {
     }
 }
 
-fn trim_ascii_whitespace(x: &[u8]) -> &[u8] {
-    x.iter().position(|x| !x.is_ascii_whitespace()).map_or_else(
-        || &x[0..0],
-        |from| {
-            let to = x.iter().rposition(|x| !x.is_ascii_whitespace()).unwrap();
-            &x[from..=to]
-        },
-    )
-}
-
 /// Deserializes an instance of type `T` from bytes of AT Response text
 pub fn from_slice<'a, T>(v: &'a [u8]) -> Result<T>
 where
@@ -744,7 +734,7 @@ where
     where
         T: de::Deserialize<'a>,
     {
-        let mut de = Deserializer::new(trim_ascii_whitespace(v));
+        let mut de = Deserializer::new(v.trim_ascii());
         let value = de::Deserialize::deserialize(&mut de)?;
         de.end()?;
         Ok(value)


### PR DESCRIPTION
We depend on embassy-sync, which uses rust 2024, hence our MSRV >= 1.85.0. [u8]::trim_ascii was stabilized in 1.80.0.