### PR TITLE
Remove hardcoded response size limit in `SimpleClient`

### DIFF
--- a/atat/src/asynch/simple_client.rs
+++ b/atat/src/asynch/simple_client.rs
@@ -1,5 +1,5 @@
 use super::AtatClient;
-use crate::{helpers::LossyStr, AtatCmd, Config, DigestResult, Digester, Error, Response};
+use crate::{helpers::LossyStr, AtatCmd, Config, DigestResult, Digester, Error, InternalError};
 use embassy_time::{with_timeout, Duration, Timer};
 use embedded_io_async::{Read, Write};
 
@@ -53,81 +53,56 @@ impl<'a, RW: Read + Write, D: Digester> SimpleClient<'a, RW, D> {
         Ok(())
     }
 
-    async fn wait_response(&mut self) -> Result<Response<256>, Error> {
-        loop {
-            match self.rw.read(&mut self.buf[self.pos..]).await {
-                Ok(n) => {
-                    self.pos += n;
-                }
-                _ => return Err(Error::Read),
-            };
+    async fn read_response_chunk(&mut self) -> Result<(), Error> {
+        self.pos += self
+            .rw
+            .read(&mut self.buf[self.pos..])
+            .await
+            .or(Err(Error::Read))?;
 
-            trace!(
-                "Buffer contents: ({:?} bytes) '{:?}'",
+        trace!(
+            "Buffer contents: ({:?} bytes) '{:?}'",
+            self.pos,
+            LossyStr(&self.buf[..self.pos])
+        );
+
+        Ok(())
+    }
+
+    fn digest(&mut self) -> (Option<Result<&[u8], InternalError<'_>>>, usize) {
+        let (result, swallowed) = self.digester.digest(&self.buf[..self.pos]);
+        match &result {
+            DigestResult::None if swallowed > 0 => debug!(
+                "Received echo or whitespace ({}/{}): {:?}",
+                swallowed,
                 self.pos,
-                LossyStr(&self.buf[..self.pos])
-            );
-
-            while self.pos > 0 {
-                let (res, swallowed) = match self.digester.digest(&self.buf[..self.pos]) {
-                    (DigestResult::None, swallowed) => {
-                        if swallowed > 0 {
-                            debug!(
-                                "Received echo or whitespace ({}/{}): {:?}",
-                                swallowed,
-                                self.pos,
-                                LossyStr(&self.buf[..swallowed])
-                            );
-                        }
-                        (None, swallowed)
-                    }
-                    (DigestResult::Urc(urc_line), swallowed) => {
-                        warn!("Unable to handle URC! Ignoring: {:?}", LossyStr(urc_line));
-                        (None, swallowed)
-                    }
-                    (DigestResult::Prompt(prompt), swallowed) => {
-                        debug!("Received prompt ({}/{})", swallowed, self.pos);
-
-                        (Some(Response::Prompt(prompt)), swallowed)
-                    }
-                    (DigestResult::Response(resp), swallowed) => {
-                        match &resp {
-                            Ok(r) => {
-                                if r.is_empty() {
-                                    debug!("Received OK ({}/{})", swallowed, self.pos)
-                                } else {
-                                    debug!(
-                                        "Received response ({}/{}): {:?}",
-                                        swallowed,
-                                        self.pos,
-                                        LossyStr(r)
-                                    );
-                                }
-                            }
-                            Err(e) => {
-                                warn!(
-                                    "Received error response ({}/{}): {:?}",
-                                    swallowed, self.pos, e
-                                );
-                            }
-                        }
-
-                        (Some(resp.into()), swallowed)
-                    }
-                };
-
-                if swallowed == 0 {
-                    embassy_futures::yield_now().await;
-                    break;
-                }
-
-                self.consume(swallowed);
-
-                if let Some(resp) = res {
-                    return Ok(resp);
-                }
+                LossyStr(&self.buf[..swallowed])
+            ),
+            DigestResult::None => {}
+            DigestResult::Urc(urc_line) => {
+                warn!("Unable to handle URC! Ignoring: {:?}", LossyStr(urc_line))
             }
+            DigestResult::Prompt(_) => {
+                debug!("Received prompt ({}/{})", swallowed, self.pos);
+            }
+            DigestResult::Response(Ok([])) => debug!("Received OK ({}/{})", swallowed, self.pos),
+            DigestResult::Response(Ok(r)) => debug!(
+                "Received response ({}/{}): {:?}",
+                swallowed,
+                self.pos,
+                LossyStr(r)
+            ),
+            DigestResult::Response(Err(e)) => warn!(
+                "Received error response ({}/{}): {:?}",
+                swallowed, self.pos, e
+            ),
         }
+        let result = match result {
+            DigestResult::Prompt(_) => Some(Ok(&[][..])),
+            DigestResult::Response(resp) => Some(resp),
+            _ => None,
+        };
+        (result, swallowed)
     }
 
     fn consume(&mut self, amt: usize) {
@@ -152,16 +127,26 @@ impl<RW: Read + Write, D: Digester> AtatClient for SimpleClient<'_, RW, D> {
 
         self.send_request(len).await?;
         if !Cmd::EXPECTS_RESPONSE_CODE {
-            cmd.parse(Ok(&[]))
-        } else {
-            let response = embassy_time::with_timeout(
-                Duration::from_millis(Cmd::MAX_TIMEOUT_MS.into()),
-                self.wait_response(),
-            )
-            .await
-            .map_err(|_| Error::Timeout)??;
-
-            cmd.parse((&response).into())
+            return cmd.parse(Ok(&[]));
         }
+
+        self.pos = 0;
+
+        let timeout = Duration::from_millis(Cmd::MAX_TIMEOUT_MS.into());
+        embassy_time::with_timeout(timeout, async {
+            loop {
+                self.read_response_chunk().await?;
+                while self.pos > 0 {
+                    match self.digest() {
+                        (Some(resp), _) => return cmd.parse(resp),
+                        (_, 0) => break,
+                        (_, swallowed) => self.consume(swallowed),
+                    }
+                }
+                embassy_futures::yield_now().await;
+            }
+        })
+        .await
+        .map_err(|_| Error::Timeout)?
     }
 }


### PR DESCRIPTION
By not converting the `DigestResult::Response` into a `Response` we can reuse the `SimpleClient` internal buffer to hold the response data until `AtatCmd::parse` is called.

@Kezii 